### PR TITLE
feat(AG2922): remove token creator bindings, allow cloudscanner to im…

### DIFF
--- a/modules/organization/iam-roles-cloudscanner.tf
+++ b/modules/organization/iam-roles-cloudscanner.tf
@@ -372,16 +372,9 @@ resource "google_project_iam_member" "cloudscanner_scaler_sa_run_invoker" {
   }
 }
 
-resource "google_project_iam_member" "upwind_management_sa_token_binding" {
-  count   = var.enable_cloudscanners ? 1 : 0
-  project = local.project
-  role    = "roles/iam.serviceAccountTokenCreator"
-  member  = "serviceAccount:${google_service_account.upwind_management_sa.email}"
-}
-
-resource "google_project_iam_member" "cloudscanner_sa_token_binding" {
-  count   = var.enable_cloudscanners ? 1 : 0
-  project = local.project
-  role    = "roles/iam.serviceAccountTokenCreator"
-  member  = "serviceAccount:${google_service_account.cloudscanner_sa[0].email}"
+resource "google_service_account_iam_member" "cloudscanner_impersonate_scaler" {
+  count              = var.enable_cloudscanners ? 1 : 0
+  service_account_id = google_service_account.cloudscanner_scaler_sa[0].id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.cloudscanner_sa[0].email}"
 }


### PR DESCRIPTION
…personate scaler

Previously we had `serviceAccountTokenCreator` at project level, allowing our 3 service accounts to impersonate each other (and... every other SA in the project).

We now authenticate through WIF, which handles most of this requirement. The remaining binding has been changed to a service account binding, so that the cloudscanner SA can impersonate the scaler when necessary.