### PR TITLE
fix(AG-2954): permissions fixes for scaling and scanning, reorganisat…

### DIFF
--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -3,7 +3,6 @@
 This Terraform module handles the onboarding of Google Cloud organizations to the Upwind platform, enabling users to
 seamlessly connect their entire organization for comprehensive monitoring and security analysis.
 
-
 ## APIs
 
 The Terraform module will enable these APIs on the orchestrator project:
@@ -81,33 +80,43 @@ No modules.
 | [google_iam_workload_identity_pool.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) | resource |
 | [google_iam_workload_identity_pool_provider.aws](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
 | [google_organization_iam_custom_role.cloudscanner_cloud_run_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_custom_role.snapshot_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_custom_role.snapshot_deleter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_custom_role.snapshot_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
 | [google_organization_iam_custom_role.upwind_management_sa_iam_read_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
 | [google_organization_iam_custom_role.upwind_management_sa_iam_write_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
-| [google_organization_iam_custom_role.snapshot_reader](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
-| [google_organization_iam_custom_role.snapshot_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_custom_role) | resource |
+| [google_organization_iam_binding.cloudscanner_cloud_run_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_binding) | resource |
+| [google_organization_iam_binding.cloudscanner_disk_writer_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_binding) | resource |
+| [google_organization_iam_binding.cloudscanner_scaler_snapshot_deleter_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_binding) | resource |
+| [google_organization_iam_binding.cloudscanner_snapshot_creator_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_binding) | resource |
+| [google_organization_iam_binding.upwind_cloudscanner_snapshot_reader_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_binding) | resource |
 | [google_organization_iam_member.cloudscanner_cloud_run_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_organization_iam_member.upwind_cloudscanner_sa_compute_viewer_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_organization_iam_member.upwind_management_sa_iam_read_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_organization_iam_member.upwind_management_sa_iam_write_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_organization_iam_member.upwind_management_sa_org_viewer_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
-| [google_organization_iam_member.upwind_cloudscanner_reader_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
-| [google_organization_iam_member.upwind_cloudscanner_writer_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_project_iam_custom_role.cloudscanner_basic_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.cloudscanner_instance_template_mgmt_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.cloudscanner_instance_template_test_creation_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.cloudscanner_scaler_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.cloudscanner_secret_access_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
-| [google_project_iam_custom_role.cloudscanner_storage_delete_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_custom_role.compute_service_agent_minimal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_custom_role.disk_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.upwind_management_sa_cloudscanner_deployment_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.cloudrun_service_agent](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.cloudscanner_instance_template_mgmt_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.cloudscanner_instance_template_test_creation_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cloudscanner_sa_basic_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cloudscanner_sa_scaler_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.cloudscanner_sa_token_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cloudscanner_scaler_sa_run_invoker](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cloudscanner_scaler_sa_scaler_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cloudscanner_scaler_secret_access_scaler_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.cloudscanner_secret_access_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.compute_service_agent_minimal](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.upwind_management_sa_cloudscanner_deployment_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.upwind_management_sa_secret_access_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_service_account_iam_member.cloudscanner_impersonate_scaler](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_project_iam_member.upwind_management_sa_token_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.enable_apis](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_secret_manager_secret.scanner_client_id](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret.scanner_client_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
@@ -120,9 +129,11 @@ No modules.
 | [google_service_account.cloudscanner_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.cloudscanner_scaler_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account.upwind_management_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
-| [google_service_account_iam_binding.cloudscanner_scaler_sa_cloudscanner_sa_user_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_binding.scaler_and_compute_can_use_cloudscanner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_member.cloudscanner_impersonate_scaler](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_service_account_iam_member.cloudscanner_token_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_service_account_iam_member.cloudscanner_workload_identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_account_iam_member.cloudscheduler_can_impersonate_scaler](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_service_account_iam_member.management_token_creator](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_service_account_iam_member.management_workload_identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [google_organization.org](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/organization) | data source |
@@ -134,19 +145,18 @@ No modules.
 | <a name="input_enable_cloudscanners"></a> [enable\_cloudscanners](#input\_enable\_cloudscanners) | Enable the creation of cloud scanners. | `bool` | `false` | no |
 | <a name="input_gcp_organization_id"></a> [gcp\_organization\_id](#input\_gcp\_organization\_id) | The GCP organization ID. | `string` | n/a | yes |
 | <a name="input_google_service_account_display_name"></a> [google\_service\_account\_display\_name](#input\_google\_service\_account\_display\_name) | The display name for the service account. | `string` | `"Upwind Security Service Account"` | no |
+| <a name="input_is_dev"></a> [is\_dev](#input\_is\_dev) | Flag to indicate if the environment is a development environment. | `bool` | `false` | no |
 | <a name="input_resource_suffix"></a> [resource\_suffix](#input\_resource\_suffix) | The suffix to append to all resources created by this module. | `string` | `""` | no |
 | <a name="input_scanner_client_id"></a> [scanner\_client\_id](#input\_scanner\_client\_id) | The client ID used for authentication with the Upwind Cloudscanner Service. | `string` | `""` | no |
 | <a name="input_scanner_client_secret"></a> [scanner\_client\_secret](#input\_scanner\_client\_secret) | The client secret for authentication with the Upwind Cloudscanner Service. | `string` | `""` | no |
 | <a name="input_upwind_apis"></a> [upwind\_apis](#input\_upwind\_apis) | List of GCP APIs to enable for Upwind Operations. | `list(string)` | <pre>[<br/>  "cloudasset.googleapis.com",<br/>  "cloudresourcemanager.googleapis.com",<br/>  "compute.googleapis.com",<br/>  "iam.googleapis.com",<br/>  "container.googleapis.com",<br/>  "sts.googleapis.com"<br/>]</pre> | no |
-| <a name="input_upwind_auth_endpoint"></a> [upwind\_auth\_endpoint](#input\_upwind\_auth\_endpoint) | The Authentication API endpoint. | `string` | `"https://oauth.upwind.io"` | no |
 | <a name="input_upwind_client_id"></a> [upwind\_client\_id](#input\_upwind\_client\_id) | The client ID used for authentication with the Upwind Authorization Service. | `string` | n/a | yes |
 | <a name="input_upwind_client_secret"></a> [upwind\_client\_secret](#input\_upwind\_client\_secret) | The client secret for authentication with the Upwind Authorization Service. | `string` | n/a | yes |
 | <a name="input_upwind_cloudscanner_apis"></a> [upwind\_cloudscanner\_apis](#input\_upwind\_cloudscanner\_apis) | List of GCP APIs to enable for Upwind Cloud Scanners. | `list(string)` | <pre>[<br/>  "secretmanager.googleapis.com",<br/>  "iam.googleapis.com",<br/>  "iamcredentials.googleapis.com",<br/>  "compute.googleapis.com",<br/>  "run.googleapis.com",<br/>  "cloudscheduler.googleapis.com",<br/>  "cloudresourcemanager.googleapis.com"<br/>]</pre> | no |
-| <a name="input_upwind_integration_endpoint"></a> [upwind\_integration\_endpoint](#input\_upwind\_integration\_endpoint) | The Integration API endpoint. | `string` | `"https://integration.upwind.io"` | no |
-| <a name="input_upwind_orchestrator_project"></a> [upwind\_orchestrator\_project](#input\_upwind\_orchestrator\_project) | The main project where the resources are created. | `string` | n/a | yes |
-| <a name="input_workload_identity_pool_project"></a> [workload\_identity\_pool\_project](#input\_workload\_identity\_pool\_project) | The project where the Workload Identity Federation pool is created. | `string` | `upwind_orchestrator_project` | no |
+| <a name="input_upwind_orchestrator_project"></a> [upwind\_orchestrator\_project](#input\_upwind\_orchestrator\_project) | The orchestrator project where Upwind resources are created. | `string` | n/a | yes |
 | <a name="input_upwind_organization_id"></a> [upwind\_organization\_id](#input\_upwind\_organization\_id) | The identifier of the Upwind organization to integrate with. | `string` | n/a | yes |
 | <a name="input_upwind_posture_apis"></a> [upwind\_posture\_apis](#input\_upwind\_posture\_apis) | List of GCP APIs to enable for Upwind Posture. | `list(string)` | <pre>[<br/>  "accessapproval.googleapis.com",<br/>  "admin.googleapis.com",<br/>  "alloydb.googleapis.com",<br/>  "apikeys.googleapis.com",<br/>  "bigquery.googleapis.com",<br/>  "dataproc.googleapis.com",<br/>  "dns.googleapis.com",<br/>  "cloudfunctions.googleapis.com",<br/>  "cloudkms.googleapis.com",<br/>  "logging.googleapis.com",<br/>  "monitoring.googleapis.com",<br/>  "redis.googleapis.com",<br/>  "sqladmin.googleapis.com",<br/>  "storage.googleapis.com",<br/>  "essentialcontacts.googleapis.com",<br/>  "serviceusage.googleapis.com"<br/>]</pre> | no |
+| <a name="input_workload_identity_pool_project"></a> [workload\_identity\_pool\_project](#input\_workload\_identity\_pool\_project) | The project where the workload identity pool is created. Defaults to the orchestrator project if not specified. | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/organization/iam-roles-cloudscanner.tf
+++ b/modules/organization/iam-roles-cloudscanner.tf
@@ -115,6 +115,7 @@ resource "google_project_iam_custom_role" "cloudscanner_scaler_role" {
   permissions = [
     "compute.instanceGroups.get",  # Required to query the status of the instance group. Should be constrained to CS MIGs.
     "compute.instanceGroups.list", # Required to query the status of the instance group. Should be constrained to CS MIGs.
+    "compute.instanceGroups.update",
     "compute.instanceGroupManagers.get",
     "compute.instanceGroupManagers.list",
     "compute.instanceGroupManagers.update", # Required to change the target size and remove instances from instance group. Should be constrained to CS MIGs.
@@ -138,22 +139,7 @@ resource "google_project_iam_custom_role" "cloudscanner_secret_access_role" {
   ]
 }
 
-# Grants permission for Cloudscanners to clean up their own resources
-# No members are added to this role as it is used for condition based access to as yet uncreated cloudscanners
-resource "google_project_iam_custom_role" "cloudscanner_storage_delete_role" {
-  count   = var.enable_cloudscanners ? 1 : 0
-  project = local.project
-  role_id = "CloudScannerStorageDeleteRole_${local.resource_suffix_underscore}"
-  title   = "upwind-cs-${local.resource_suffix_hyphen}-storage-delete"
-
-  permissions = [
-    "compute.snapshots.delete",
-    "compute.disks.delete",
-  ]
-}
-
 # Grants permission for Cloudscanners to manage their own instance templates
-# No members are added to this role as it is used for condition based access to as yet uncreated cloudscanners
 resource "google_project_iam_custom_role" "cloudscanner_instance_template_mgmt_role" {
   count   = var.enable_cloudscanners ? 1 : 0
   role_id = "CloudScannerInstTmplMgmtRole_${local.resource_suffix_underscore}"
@@ -169,7 +155,6 @@ resource "google_project_iam_custom_role" "cloudscanner_instance_template_mgmt_r
 }
 
 # Grants permission for Cloudscanners to test create their own instance templates when updating the template
-# No members are added to this role as it is used for condition based access to as yet uncreated cloudscanners
 resource "google_project_iam_custom_role" "cloudscanner_instance_template_test_creation_role" {
   count   = var.enable_cloudscanners ? 1 : 0
   role_id = "CloudScannerInstTmplTestCreationRole_${local.resource_suffix_underscore}"
@@ -186,6 +171,7 @@ resource "google_project_iam_custom_role" "cloudscanner_instance_template_test_c
 
 ### IAM Members
 
+# Required for the management service account to deploy the CloudScanner resources
 resource "google_project_iam_member" "upwind_management_sa_cloudscanner_deployment_role_member" {
   count   = var.enable_cloudscanners ? 1 : 0
   project = local.project
@@ -256,19 +242,45 @@ resource "google_organization_iam_custom_role" "snapshot_reader" {
   ]
 }
 
-resource "google_organization_iam_custom_role" "snapshot_writer" {
+resource "google_organization_iam_custom_role" "snapshot_creator" {
   count       = var.enable_cloudscanners ? 1 : 0
   org_id      = data.google_organization.org.org_id
-  role_id     = "CloudScannerSnapshotWriter_${local.resource_suffix_underscore}"
-  title       = "Upwind Snapshot Writer"
-  description = "Create/delete operations restricted to Upwind-managed resources"
+  role_id     = "CloudScannerSnapshotCreator_${local.resource_suffix_underscore}"
+  title       = "Upwind Snapshot Creator"
+  description = "Snapshot Create operations in any project"
+
+  permissions = [
+    "compute.snapshots.create",
+    "compute.snapshots.setLabels",
+    "compute.snapshots.useReadOnly"
+  ]
+}
+
+resource "google_organization_iam_custom_role" "snapshot_deleter" {
+  count       = var.enable_cloudscanners ? 1 : 0
+  org_id      = data.google_organization.org.org_id
+  role_id     = "CloudScannerSnapshotDeleter_${local.resource_suffix_underscore}"
+  title       = "Upwind Snapshot Deleter"
+  description = "Delete operations restricted to Upwind-managed resources"
 
   permissions = [
     # Write operations - restricted by IAM condition
-    "compute.snapshots.create",
     "compute.snapshots.delete",
+  ]
+}
+
+resource "google_project_iam_custom_role" "disk_writer" {
+  count       = var.enable_cloudscanners ? 1 : 0
+  project     = local.project
+  role_id     = "CloudScannerDiskWriter_${local.resource_suffix_underscore}"
+  title       = "Upwind Disk Writer"
+  description = "Disk Write operations in orchestrator project"
+
+  permissions = [
     "compute.disks.create",
     "compute.disks.delete",
+    "compute.disks.setLabels",
+    "compute.disks.use",
   ]
 }
 
@@ -294,12 +306,15 @@ resource "google_organization_iam_member" "upwind_management_sa_iam_write_role_m
   }
 }
 
-# Creating binding to allow scaler service account to operate on resources owned by scanner service account.
-resource "google_service_account_iam_binding" "cloudscanner_scaler_sa_cloudscanner_sa_user_binding" {
+# Allow scaler to impersonate scanner SA AND allow Compute Engine service to use scanner SA for VM operations
+resource "google_service_account_iam_binding" "scaler_and_compute_can_use_cloudscanner" {
   count              = var.enable_cloudscanners ? 1 : 0
   service_account_id = google_service_account.cloudscanner_sa[0].id
   role               = "roles/iam.serviceAccountUser"
-  members            = ["serviceAccount:${google_service_account.cloudscanner_scaler_sa[0].email}"]
+  members = [
+    "serviceAccount:${google_service_account.cloudscanner_scaler_sa[0].email}",
+    "serviceAccount:${data.google_project.current.number}@cloudservices.gserviceaccount.com"
+  ]
 }
 
 resource "google_project_iam_member" "cloudscanner_sa_basic_role_member" {
@@ -318,27 +333,64 @@ resource "google_organization_iam_member" "upwind_cloudscanner_sa_compute_viewer
 }
 
 # Required to get disks and snapshots of target instances across projects
-resource "google_organization_iam_member" "upwind_cloudscanner_reader_role" {
+resource "google_organization_iam_binding" "upwind_cloudscanner_snapshot_reader_role_binding" {
   count  = var.enable_cloudscanners ? 1 : 0
   org_id = data.google_organization.org.org_id
   role   = google_organization_iam_custom_role.snapshot_reader[0].name
-  member = "serviceAccount:${google_service_account.cloudscanner_sa[0].email}"
+  members = [
+    "serviceAccount:${google_service_account.cloudscanner_sa[0].email}",
+    "serviceAccount:${google_service_account.cloudscanner_scaler_sa[0].email}"
+  ]
 }
 
-# Required to create/delete snapshots and disks after scanning
-resource "google_organization_iam_member" "upwind_cloudscanner_writer_role" {
+# Required for CloudScanner to create snapshots in any project
+# Snapshot creation happens in the same project as the source disk
+# so we need to allow snapshot creation in all projects
+resource "google_organization_iam_binding" "cloudscanner_snapshot_creator_role_binding" {
   count  = var.enable_cloudscanners ? 1 : 0
   org_id = data.google_organization.org.org_id
-  role   = google_organization_iam_custom_role.snapshot_writer[0].name
-  member = "serviceAccount:${google_service_account.cloudscanner_sa[0].email}"
+  role   = google_organization_iam_custom_role.snapshot_creator[0].name
+  members = [
+    "serviceAccount:${google_service_account.cloudscanner_sa[0].email}",
+    "serviceAccount:${google_service_account.cloudscanner_scaler_sa[0].email}"
+  ]
 
   condition {
-    title       = "Restrict write operations to Upwind-managed resources"
-    description = "Only allow write operations on snapshots starting with 'snap-' and disks starting with 'vol-snap-'"
-    expression  = <<-EOT
-      (resource.type != "compute.snapshots" || resource.name.startsWith("snap-")) &&
-      (resource.type != "compute.disks" || resource.name.startsWith("vol-snap-"))
-    EOT
+    # snapshot creation is tested against project. Allow snapshot creation in all projects
+    title      = "Upwind Cloud Scanner Snapshot Creator"
+    expression = ""
+  }
+}
+
+# Limit snapshot deletion permissions to Upwind-generated snapshots only
+resource "google_organization_iam_binding" "cloudscanner_scaler_snapshot_deleter_role_binding" {
+  count  = var.enable_cloudscanners ? 1 : 0
+  org_id = data.google_organization.org.org_id
+  role   = google_organization_iam_custom_role.snapshot_deleter[0].name
+  members = [
+    "serviceAccount:${google_service_account.cloudscanner_sa[0].email}",
+    "serviceAccount:${google_service_account.cloudscanner_scaler_sa[0].email}"
+  ]
+  condition {
+    # Limit storage deletion permissions to snapshots we generate only
+    title      = "Upwind Cloud Scanner Snapshot Writer"
+    expression = "resource.name.extract('projects/.*/global/snapshots/(snap-.*)') != ''"
+  }
+}
+
+# Limit disk creation/deletion permissions to Upwind named disks only in orchestrator project
+resource "google_project_iam_binding" "cloudscanner_disk_writer_role_binding" {
+  count   = var.enable_cloudscanners ? 1 : 0
+  project = local.project
+  role    = google_project_iam_custom_role.disk_writer[0].name
+  members = [
+    "serviceAccount:${google_service_account.cloudscanner_sa[0].email}",
+    "serviceAccount:${google_service_account.cloudscanner_scaler_sa[0].email}"
+  ]
+  condition {
+    # Limit disk creation/deletion permissions to Upwind named disks only in orchestrator project
+    title      = "Upwind Cloud Scanner Disk Writer"
+    expression = "resource.name.extract('projects/${local.project}/zones/.*/disks/(vol-snap-.*)') != ''"
   }
 }
 
@@ -389,6 +441,7 @@ resource "google_project_iam_member" "upwind_management_sa_secret_access_role_me
   }
 }
 
+# Only grant access to the Upwind Scanner Client ID and Secret
 resource "google_project_iam_member" "cloudscanner_secret_access_role_member" {
   count   = var.enable_cloudscanners ? 1 : 0
   project = local.project
@@ -434,9 +487,114 @@ resource "google_project_iam_member" "cloudscanner_scaler_sa_run_invoker" {
   }
 }
 
+resource "google_project_iam_member" "cloudscanner_instance_template_mgmt_member" {
+  count   = var.enable_cloudscanners ? 1 : 0
+  project = local.project
+  role    = google_project_iam_custom_role.cloudscanner_instance_template_mgmt_role[0].name
+  member  = "serviceAccount:${google_service_account.cloudscanner_scaler_sa[0].email}" # Cloud Scanner Scaler (Cloud Run)"
+
+  condition {
+    # Limit the use of the roles to cloudscanner only instance templates
+    title      = "Upwind Cloud Scanner Instance Template Management"
+    expression = "resource.name.extract('projects/${local.project}/regions/.*/instanceTemplates/(upwind-tpl-.*)') != ''"
+  }
+}
+
+resource "google_project_iam_member" "cloudscanner_instance_template_test_creation_member" {
+  count   = var.enable_cloudscanners ? 1 : 0
+  project = local.project
+  role    = google_project_iam_custom_role.cloudscanner_instance_template_test_creation_role[0].name
+  member  = "serviceAccount:${google_service_account.cloudscanner_scaler_sa[0].email}" # Cloud Scanner Scaler (Cloud Run)"
+
+  condition {
+    # Upgrading templates performs a 'dry-run' of instance creation, limit to resources using this pattern
+    title      = "Upwind Cloud Scanner Instance Template Upgrade"
+    expression = "resource.name.endsWith('-0000')"
+  }
+}
+
+# Allows the CloudScanner to impersonate the CloudScanner Scaler Service Account
 resource "google_service_account_iam_member" "cloudscanner_impersonate_scaler" {
   count              = var.enable_cloudscanners ? 1 : 0
   service_account_id = google_service_account.cloudscanner_scaler_sa[0].id
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${google_service_account.cloudscanner_sa[0].email}"
+}
+
+# Allows the Google Cloud Run service agent to manage Cloud Run jobs
+resource "google_project_iam_member" "cloudrun_service_agent" {
+  count   = var.enable_cloudscanners ? 1 : 0
+  project = local.project
+  role    = "roles/run.serviceAgent"
+  member  = "serviceAccount:service-${data.google_project.current.number}@serverless-robot-prod.iam.gserviceaccount.com"
+}
+
+# Required when scaling up the Instance Group as the Compute Engine service agent
+# is the entity that performs the scaling operations
+resource "google_project_iam_custom_role" "compute_service_agent_minimal" {
+  count   = var.enable_cloudscanners ? 1 : 0
+  project = local.project
+  role_id = "ComputeServiceAgentMinimal_${local.resource_suffix_underscore}"
+  title   = "Minimal Compute Service Agent Permissions"
+
+  permissions = [
+    "compute.disks.create",
+    "compute.disks.use",
+    "compute.instances.create",
+    "compute.instances.use",
+    "compute.instances.delete",
+    "compute.instances.setLabels",
+    "compute.instances.setTags",
+    "compute.instances.setMetadata",
+    "compute.instances.setServiceAccount",
+    "compute.subnetworks.use",
+    "compute.instanceGroups.update"
+  ]
+}
+
+resource "google_project_iam_member" "compute_service_agent_minimal" {
+  count   = var.enable_cloudscanners ? 1 : 0
+  project = local.project
+  role    = google_project_iam_custom_role.compute_service_agent_minimal[0].name
+  member  = "serviceAccount:${data.google_project.current.number}@cloudservices.gserviceaccount.com"
+}
+
+# Allow management SA to create tokens for scanner SA
+resource "google_service_account_iam_member" "management_can_impersonate_scanner" {
+  count              = var.enable_cloudscanners ? 1 : 0
+  service_account_id = google_service_account.cloudscanner_sa[0].id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.upwind_management_sa.email}"
+}
+
+# Allow management SA to create tokens for scaler SA
+resource "google_service_account_iam_member" "management_can_impersonate_scaler" {
+  count              = var.enable_cloudscanners ? 1 : 0
+  service_account_id = google_service_account.cloudscanner_scaler_sa[0].id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.upwind_management_sa.email}"
+}
+
+# Allow scanner SA to create tokens for scaler SA
+resource "google_service_account_iam_member" "scanner_can_impersonate_scaler" {
+  count              = var.enable_cloudscanners ? 1 : 0
+  service_account_id = google_service_account.cloudscanner_scaler_sa[0].id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.cloudscanner_sa[0].email}"
+}
+
+# Allow scaler SA to create tokens for scanner SA
+resource "google_service_account_iam_member" "scaler_can_impersonate_scanner" {
+  count              = var.enable_cloudscanners ? 1 : 0
+  service_account_id = google_service_account.cloudscanner_sa[0].id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.cloudscanner_scaler_sa[0].email}"
+}
+
+# Allow Cloud Scheduler to impersonate scaler SA
+resource "google_service_account_iam_member" "cloudscheduler_can_impersonate_scaler" {
+  count              = var.enable_cloudscanners ? 1 : 0
+  service_account_id = google_service_account.cloudscanner_scaler_sa[0].id
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:service-${data.google_project.current.number}@gcp-sa-cloudscheduler.iam.gserviceaccount.com"
 }

--- a/modules/organization/main.tf
+++ b/modules/organization/main.tf
@@ -22,3 +22,7 @@ provider "google" {
 data "google_organization" "org" {
   organization = var.gcp_organization_id
 }
+
+data "google_project" "current" {
+  project_id = local.project
+}

--- a/modules/organization/outputs.tf
+++ b/modules/organization/outputs.tf
@@ -22,3 +22,8 @@ output "upwind_management_service_account_project" {
   description = "The project ID of the Upwind Management Service Account."
   value       = google_service_account.upwind_management_sa.project
 }
+
+output "upwind_workload_identity_pool_id" {
+  description = "The ID of the Upwind Workload Identity Pool."
+  value       = google_iam_workload_identity_pool.main.workload_identity_pool_id
+}

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -104,16 +104,10 @@ variable "scanner_client_secret" {
   default     = ""
 }
 
-variable "upwind_auth_endpoint" {
-  description = "The Authentication API endpoint."
-  type        = string
-  default     = "https://oauth.upwind.io"
-}
-
-variable "upwind_integration_endpoint" {
-  description = "The Integration API endpoint."
-  type        = string
-  default     = "https://integration.upwind.io"
+variable "is_dev" {
+  description = "Flag to indicate if the environment is a development environment."
+  type        = bool
+  default     = false
 }
 
 # endregion upwind
@@ -131,7 +125,7 @@ variable "gcp_organization_id" {
 }
 
 variable "upwind_orchestrator_project" {
-  description = "The main project where the resources are created."
+  description = "The orchestrator project where Upwind resources are created."
   type        = string
 
   validation {
@@ -141,7 +135,7 @@ variable "upwind_orchestrator_project" {
 }
 
 variable "workload_identity_pool_project" {
-  description = "The project where the workload identity pool is created."
+  description = "The project where the workload identity pool is created. Defaults to the orchestrator project if not specified."
   type        = string
   default     = ""
 

--- a/modules/organization/wif.tf
+++ b/modules/organization/wif.tf
@@ -1,7 +1,5 @@
 locals {
-  # Select dev or prod AWS account based on auth endpoint
-  is_dev             = strcontains(var.upwind_auth_endpoint, "upwind.dev") || strcontains(var.upwind_integration_endpoint, "upwind.dev")
-  upwind_aws_account = local.is_dev ? "437279811180" : "627244208106"
+  upwind_aws_account = var.is_dev ? "437279811180" : "627244208106"
   timestamp          = formatdate("YYYYMMDD-hhmm", timestamp())
 }
 


### PR DESCRIPTION
…ion of roles

- Moving all IAM resources to onboarding: those created with each cloudscanner (tied to scanner ID) would gradually fill the policy on the role, which is limited to a relatively small size. Conditions have been rewritten to use `extract` and match against the defined Upwind naming conventions
- The reduction of `roles.storageAdmin` proved too simple, missing permissions have since been discovered and roles have been reorganised as a result: `snapshot_reader`, `snapshot_creator`, `disk_writer` for example.
- Compute Service Agent has been discovered to require permissions as it executes the scaling of Instance Groups on behalf of the Scaler Service Account.
- Removal of `serviceAccountTokenCreator` also proved to be naive - this is required in the orchestrator project.
- `is_dev` variable added to replace the HTTP endpoints, as requests are no longer made from Terraform.