### PR TITLE
chore(AG-3006): create backport with terraform version 1.9.5

### DIFF
--- a/modules/organization/secrets.tf
+++ b/modules/organization/secrets.tf
@@ -34,23 +34,23 @@ resource "google_secret_manager_secret" "scanner_client_secret" {
   }
 }
 resource "google_secret_manager_secret_version" "upwind_client_id_v1" {
-  secret         = google_secret_manager_secret.upwind_client_id.id
-  secret_data_wo = var.upwind_client_id
+  secret      = google_secret_manager_secret.upwind_client_id.id
+  secret_data = var.upwind_client_id
 }
 
 resource "google_secret_manager_secret_version" "upwind_client_secret_v1" {
-  secret         = google_secret_manager_secret.upwind_client_secret.id
-  secret_data_wo = var.upwind_client_secret
+  secret      = google_secret_manager_secret.upwind_client_secret.id
+  secret_data = var.upwind_client_secret
 }
 
 resource "google_secret_manager_secret_version" "scanner_client_id_v1" {
-  count          = var.enable_cloudscanners ? 1 : 0
-  secret         = google_secret_manager_secret.scanner_client_id[0].id
-  secret_data_wo = var.scanner_client_id
+  count       = var.enable_cloudscanners ? 1 : 0
+  secret      = google_secret_manager_secret.scanner_client_id[0].id
+  secret_data = var.scanner_client_id
 }
 
 resource "google_secret_manager_secret_version" "scanner_client_secret_v1" {
-  count          = var.enable_cloudscanners ? 1 : 0
-  secret         = google_secret_manager_secret.scanner_client_secret[0].id
-  secret_data_wo = var.scanner_client_secret
+  count       = var.enable_cloudscanners ? 1 : 0
+  secret      = google_secret_manager_secret.scanner_client_secret[0].id
+  secret_data = var.scanner_client_secret
 }

--- a/modules/organization/versions.tf
+++ b/modules/organization/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.11.0"
+  required_version = ">= 1.9.5"
 
   required_providers {
     google = {


### PR DESCRIPTION
Write only attributes were only introduced in 1.11, so this version removes those and uses versions above 1.9.5. This will mean that secret data is written to Terraform state.