### PR TITLE
chore: align semantic-release config with standard practices

### DIFF
--- a/.config/.releaserc.json
+++ b/.config/.releaserc.json
@@ -16,10 +16,6 @@
         "preset": "conventionalcommits",
         "releaseRules": [
           {
-            "release": "patch",
-            "type": "chore"
-          },
-          {
             "release": "minor",
             "type": "feat"
           },


### PR DESCRIPTION
- Remove chore type from releaseRules to prevent chore commits from triggering releases
- Aligns with conventional commits specification where chore has no implicit effect on semantic versioning
- Future chore commits will not create releases, following standard behavior