### PR TITLE
chore: add dependency-specific release rule

### DIFF
--- a/.config/.releaserc.json
+++ b/.config/.releaserc.json
@@ -16,6 +16,11 @@
         "preset": "conventionalcommits",
         "releaseRules": [
           {
+            "release": "patch",
+            "type": "chore",
+            "scope": "deps"
+          },
+          {
             "release": "minor",
             "type": "feat"
           },


### PR DESCRIPTION
- Add chore(deps) scope rule to trigger patch releases for dependency updates
- Ensures Dependabot commits create releases while other chore commits don't
- Maintains standard practice of treating dependency updates as release-worthy