### PR TITLE
chore(AG-3232): support outputting wif provider during terraform onboarding

### DIFF
--- a/examples/organization/outputs.tf
+++ b/examples/organization/outputs.tf
@@ -24,6 +24,11 @@ output "organization_service_account_name" {
   value       = module.upwind_organization_onboarding.upwind_management_service_account_name
 }
 
+output "workload_identity_provider_name" {
+  description = "Full path name of the workload identity pool provider"
+  value       = module.upwind_organization_onboarding.workload_identity_provider_name
+}
+
 # Summary outputs
 
 output "organization_onboarded" {

--- a/modules/organization/outputs.tf
+++ b/modules/organization/outputs.tf
@@ -27,3 +27,8 @@ output "upwind_workload_identity_pool_id" {
   description = "The ID of the Upwind Workload Identity Pool."
   value       = google_iam_workload_identity_pool.main.workload_identity_pool_id
 }
+
+output "workload_identity_provider_name" {
+  description = "Full path name of the workload identity pool provider"
+  value       = "projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.main.workload_identity_pool_id}/providers/${google_iam_workload_identity_pool_provider.aws.workload_identity_pool_provider_id}"
+}


### PR DESCRIPTION
This allows the customer to copy and paste the value directly from Terraform output into the next command to generate a WIF config, without referring to extra `gcloud` commands in the docs.