### PR TITLE
fix(AG-3476): add folderViewer permissions to management account

### DIFF
--- a/modules/organization/README.md
+++ b/modules/organization/README.md
@@ -99,6 +99,7 @@ No modules.
 | [google_organization_iam_member.upwind_cloudscanner_sa_compute_viewer_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_organization_iam_member.upwind_management_sa_iam_read_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_organization_iam_member.upwind_management_sa_org_viewer_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
+| [google_organization_iam_member.upwind_management_sa_folder_viewer_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_organization_iam_member.upwind_management_sa_storage_reader_role_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/organization_iam_member) | resource |
 | [google_project_iam_custom_role.cloudscanner_basic_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.cloudscanner_instance_template_mgmt_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |

--- a/modules/organization/iam-roles.tf
+++ b/modules/organization/iam-roles.tf
@@ -11,6 +11,12 @@ resource "google_organization_iam_member" "upwind_management_sa_org_viewer_role_
   member = "serviceAccount:${google_service_account.upwind_management_sa.email}"
 }
 
+resource "google_organization_iam_member" "upwind_management_sa_folder_viewer_role_member" {
+  org_id = data.google_organization.org.org_id
+  role   = "roles/resourcemanager.folderViewer"
+  member = "serviceAccount:${google_service_account.upwind_management_sa.email}"
+}
+
 # Specifically grant permissions to read storage objects
 # This is a reduction from the storageAdmin role to grant read only access
 resource "google_organization_iam_custom_role" "storage_reader_role" {


### PR DESCRIPTION
This gives us the ability to list folders under the organization node, which we will need to effectively list them and collect info on OUs/folders.