### PR TITLE
feat(AG-3683) consolidate roles, consistent naming, permission removal

### DIFF
--- a/examples/multiproject/main.tf
+++ b/examples/multiproject/main.tf
@@ -10,7 +10,6 @@ module "upwind_organization_onboarding" {
   upwind_client_secret   = var.upwind_client_secret
 
   # Required Google Cloud configuration
-  gcp_organization_id         = var.gcp_organization_id
   upwind_orchestrator_project = var.upwind_orchestrator_project
 
   # Optional configuration

--- a/modules/_shared/iam/outputs.tf
+++ b/modules/_shared/iam/outputs.tf
@@ -124,9 +124,7 @@ output "snapshot_deleter_permissions" {
 
 output "storage_object_reader_permissions" {
   description = "List of IAM permissions for storage object reader role."
-  value = [
-    "storage.objects.get",
-  ]
+  value       = var.storage_object_reader_permissions
 }
 
 output "cloud_run_permissions" {

--- a/modules/_shared/iam/outputs.tf
+++ b/modules/_shared/iam/outputs.tf
@@ -62,7 +62,6 @@ output "google_service_account_iam_binding" {
   description = "The IAM bindings for service accounts."
   value = {
     scaler_and_compute_can_use_cloudscanner = var.enable_cloudscanners ? google_service_account_iam_binding.scaler_and_compute_can_use_cloudscanner[0] : null
-    cloudscanner_impersonate_scaler         = var.enable_cloudscanners ? google_service_account_iam_member.cloudscanner_impersonate_scaler[0] : null
     management_can_impersonate_scanner      = var.enable_cloudscanners ? google_service_account_iam_member.management_can_impersonate_scanner[0] : null
     management_can_impersonate_scaler       = var.enable_cloudscanners ? google_service_account_iam_member.management_can_impersonate_scaler[0] : null
     scanner_can_impersonate_scaler          = var.enable_cloudscanners ? google_service_account_iam_member.scanner_can_impersonate_scaler[0] : null

--- a/modules/_shared/iam/permissions.tf
+++ b/modules/_shared/iam/permissions.tf
@@ -53,7 +53,6 @@ variable "deployment_permissions" {
     "iam.serviceAccounts.actAs", # Required to assign a service account to instances
     "iam.serviceAccounts.getIamPolicy",
     "iam.serviceAccounts.setIamPolicy",
-    "iam.serviceAccounts.getAccessToken", # For service account token operations
     # Required for Terraform to check operation status
     "compute.regionOperations.get",
     # Required basic service usage

--- a/modules/_shared/iam/permissions.tf
+++ b/modules/_shared/iam/permissions.tf
@@ -1,3 +1,168 @@
+variable "deployment_permissions" {
+  description = "List of IAM permissions for deployment operations."
+  type        = list(string)
+  default = [
+    # Compute Engine resource creation permissions
+    "compute.instanceTemplates.create",
+    "compute.instanceTemplates.delete",
+    "compute.instanceTemplates.get",
+    "compute.instanceGroupManagers.create",
+    "compute.instanceGroupManagers.delete",
+    "compute.instanceGroupManagers.get",
+    "compute.instanceGroupManagers.update",
+    "compute.instanceGroups.delete",
+    "compute.instances.create",
+    "compute.instances.delete",
+    "compute.instances.get",
+    "compute.instances.setMetadata",
+    "compute.instances.setTags",
+    "compute.instances.setLabels",
+    "compute.disks.create",
+    "compute.disks.get",
+    "compute.disks.delete",
+    # Networking resource creation permissions
+    "compute.networks.create",
+    "compute.networks.get",
+    "compute.networks.updatePolicy",
+    "compute.networks.delete",
+    "compute.subnetworks.create",
+    "compute.subnetworks.get",
+    "compute.subnetworks.use",
+    "compute.subnetworks.delete",
+    "compute.routers.create",
+    "compute.routers.get",
+    "compute.routers.update", # For creating NAT on the router
+    "compute.routers.delete",
+    "compute.firewalls.create",
+    "compute.firewalls.get",
+    "compute.firewalls.delete",
+    # Cloud Run creation permissions
+    "run.jobs.create",
+    "run.jobs.get",
+    "run.jobs.delete",
+    # Cloud Scheduler creation permissions
+    "cloudscheduler.jobs.create",
+    "cloudscheduler.jobs.get",
+    "cloudscheduler.jobs.enable",
+    "cloudscheduler.jobs.delete",
+    # IAM permissions for setting up project bindings
+    "resourcemanager.projects.getIamPolicy",
+    "resourcemanager.projects.setIamPolicy",
+    # Service Account reference permission
+    "iam.serviceAccounts.get",
+    "iam.serviceAccounts.actAs", # Required to assign a service account to instances
+    "iam.serviceAccounts.getIamPolicy",
+    "iam.serviceAccounts.setIamPolicy",
+    "iam.serviceAccounts.getAccessToken", # For service account token operations
+    # Required for Terraform to check operation status
+    "compute.regionOperations.get",
+    # Required basic service usage
+    "serviceusage.services.use"
+  ]
+}
+
+variable "cloudscanner_basic_permissions" {
+  description = "List of IAM permissions for basic CloudScanner operations."
+  type        = list(string)
+  default = [
+    # Basic permissions for CloudScanner operation
+    "compute.disks.createSnapshot",
+    "compute.disks.get",
+    "compute.disks.list",
+    "compute.instances.attachDisk",
+    "compute.instances.detachDisk",
+    "compute.instances.get",
+    "compute.instances.list",
+    "compute.snapshots.get",
+    "compute.snapshots.setLabels",
+    "compute.snapshots.useReadOnly",
+    "compute.zoneOperations.get",
+    "compute.globalOperations.get",
+    "iam.serviceAccounts.actAs",
+  ]
+}
+
+variable "cloudscanner_scaler_permissions" {
+  description = "List of IAM permissions for CloudScanner Scaler operations."
+  type        = list(string)
+  default = [
+    # Permissions for the CloudScanner Scaler
+    "compute.instanceGroups.get",  # Required to query the status of the instance group. Should be constrained to CS MIGs.
+    "compute.instanceGroups.list", # Required to query the status of the instance group. Should be constrained to CS MIGs.
+    "compute.instanceGroups.update",
+    "compute.instanceGroupManagers.get",
+    "compute.instanceGroupManagers.list",
+    "compute.instanceGroupManagers.update", # Required to change the target size and remove instances from instance group. Should be constrained to CS MIGs.
+    "compute.zoneOperations.get",           # The internal implementation queries the zone operations when removing disks.
+    "compute.globalOperations.get",         # The internal implementation queries the global operations when removing snapshots.
+    "compute.subnetworks.get",
+    "compute.subnetworks.use",
+  ]
+}
+
+variable "cloudscanner_secret_access_permissions" {
+  description = "List of IAM permissions for CloudScanner secret access."
+  type        = list(string)
+  default = [
+    # Permissions for accessing secrets in Secret Manager
+    "secretmanager.versions.access",
+    "secretmanager.versions.list",
+    "secretmanager.secrets.get",
+    "secretmanager.secrets.list",
+  ]
+}
+
+variable "cloudscanner_instance_template_mgmt_permissions" {
+  description = "List of IAM permissions for CloudScanner instance template management."
+  type        = list(string)
+  default = [
+    "compute.instanceTemplates.get",
+    "compute.instanceTemplates.create",
+    "compute.instanceTemplates.delete",
+    "compute.instanceTemplates.useReadOnly",
+  ]
+}
+
+variable "cloudscanner_instance_template_test_creation_permissions" {
+  description = "List of IAM permissions for CloudScanner instance template test creation."
+  type        = list(string)
+  default = [
+    "compute.instances.create",
+    "compute.instances.setMetadata",
+    "compute.instances.setLabels",
+    "compute.disks.create",
+  ]
+}
+
+variable "disk_writer_permissions" {
+  description = "List of IAM permissions for disk writer role."
+  type        = list(string)
+  default = [
+    "compute.disks.create",
+    "compute.disks.delete",
+    "compute.disks.setLabels",
+    "compute.disks.use",
+  ]
+}
+
+variable "compute_service_agent_minimal_permissions" {
+  description = "List of IAM permissions for minimal compute service agent role."
+  type        = list(string)
+  default = [
+    "compute.disks.create",
+    "compute.disks.use",
+    "compute.instances.create",
+    "compute.instances.use",
+    "compute.instances.delete",
+    "compute.instances.setLabels",
+    "compute.instances.setTags",
+    "compute.instances.setMetadata",
+    "compute.instances.setServiceAccount",
+    "compute.subnetworks.use",
+    "compute.instanceGroups.update"
+  ]
+}
+
 variable "storage_read_permissions" {
   description = "List of IAM permissions for storage read access."
   type        = list(string)

--- a/modules/_shared/iam/permissions.tf
+++ b/modules/_shared/iam/permissions.tf
@@ -219,7 +219,6 @@ variable "snapshot_reader_permissions" {
     "compute.zoneOperations.get",
     "compute.globalOperations.get",
     "compute.regionOperations.get",
-    "iam.serviceAccounts.getAccessToken",
   ]
 }
 

--- a/modules/_shared/iam/permissions.tf
+++ b/modules/_shared/iam/permissions.tf
@@ -20,6 +20,7 @@ variable "deployment_permissions" {
     "compute.disks.create",
     "compute.disks.get",
     "compute.disks.delete",
+    "compute.zones.list",
     # Networking resource creation permissions
     "compute.networks.create",
     "compute.networks.get",
@@ -40,6 +41,7 @@ variable "deployment_permissions" {
     "run.jobs.create",
     "run.jobs.get",
     "run.jobs.delete",
+    "run.executions.list",
     # Cloud Scheduler creation permissions
     "cloudscheduler.jobs.create",
     "cloudscheduler.jobs.get",
@@ -78,6 +80,7 @@ variable "cloudscanner_basic_permissions" {
     "compute.zoneOperations.get",
     "compute.globalOperations.get",
     "iam.serviceAccounts.actAs",
+    "run.executions.list",
   ]
 }
 

--- a/modules/_shared/iam/permissions.tf
+++ b/modules/_shared/iam/permissions.tf
@@ -82,6 +82,8 @@ variable "storage_object_reader_permissions" {
   type        = list(string)
   default = [
     "storage.objects.get",
+    "storage.buckets.get",
+    "storage.buckets.list",
   ]
 }
 

--- a/modules/_shared/iam/roles.tf
+++ b/modules/_shared/iam/roles.tf
@@ -3,7 +3,7 @@
 # Used by the management service account to deploy the cloudscanner resources
 resource "google_project_iam_custom_role" "upwind_management_sa_cloudscanner_deployment_role" {
   count       = var.enable_cloudscanners ? 1 : 0
-  project     = var.upwind_orchestrator_project
+  project     = local.project
   role_id     = "CloudScannerDeploymentRole_${local.resource_suffix_underscore}"
   title       = "upwind-role-${local.resource_suffix_hyphen}-cs-deployment"
   description = "Minimum permissions required to deploy the Cloudscanner resources"

--- a/modules/_shared/iam/roles.tf
+++ b/modules/_shared/iam/roles.tf
@@ -5,7 +5,7 @@ resource "google_project_iam_custom_role" "upwind_management_sa_cloudscanner_dep
   count       = var.enable_cloudscanners ? 1 : 0
   project     = var.upwind_orchestrator_project
   role_id     = "CloudScannerDeploymentRole_${local.resource_suffix_underscore}"
-  title       = "upwind-mgmt-${local.resource_suffix_hyphen}-cs-deployment"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-cs-deployment"
   description = "Minimum permissions required to deploy the Cloudscanner resources"
   permissions = [
     # Compute Engine resource creation permissions
@@ -79,7 +79,7 @@ resource "google_project_iam_custom_role" "cloudscanner_basic_role" {
   count       = var.enable_cloudscanners ? 1 : 0
   project     = local.project
   role_id     = "CloudScannerBasicRole_${local.resource_suffix_underscore}"
-  title       = "upwind-cs-${local.resource_suffix_hyphen}-basic"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-basic"
   description = "Minimum permissions required for Cloudscanner operations"
 
   permissions = [
@@ -104,7 +104,7 @@ resource "google_project_iam_custom_role" "cloudscanner_scaler_role" {
   count       = var.enable_cloudscanners ? 1 : 0
   role_id     = "CloudScannerScalerRole_${local.resource_suffix_underscore}"
   project     = local.project
-  title       = "upwind-cs-${local.resource_suffix_hyphen}-scaler-base"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-scaler-base"
   description = "Minimum permissions required for Cloudscanner Scaler operations"
 
   permissions = [
@@ -126,7 +126,7 @@ resource "google_project_iam_custom_role" "cloudscanner_secret_access_role" {
   count   = var.enable_cloudscanners ? 1 : 0
   project = local.project
   role_id = "CloudScannerSecretAccessRole_${local.resource_suffix_underscore}"
-  title   = "upwind-cs-${local.resource_suffix_hyphen}-secret-access"
+  title   = "upwind-role-${local.resource_suffix_hyphen}-secret-access"
 
   permissions = [
     "secretmanager.versions.list",
@@ -139,7 +139,7 @@ resource "google_project_iam_custom_role" "cloudscanner_instance_template_mgmt_r
   count   = var.enable_cloudscanners ? 1 : 0
   role_id = "CloudScannerInstTmplMgmtRole_${local.resource_suffix_underscore}"
   project = local.project
-  title   = "upwind-cs-${local.resource_suffix_hyphen}-instance-template-mgmt"
+  title   = "upwind-role-${local.resource_suffix_hyphen}-instance-template-mgmt"
 
   permissions = [
     "compute.instanceTemplates.get",
@@ -154,7 +154,7 @@ resource "google_project_iam_custom_role" "cloudscanner_instance_template_test_c
   count   = var.enable_cloudscanners ? 1 : 0
   role_id = "CloudScannerInstTmplTestCreationRole_${local.resource_suffix_underscore}"
   project = local.project
-  title   = "upwind-cs-${local.resource_suffix_hyphen}-instance-template-mgmt-test-creation"
+  title   = "upwind-role-${local.resource_suffix_hyphen}-instance-template-mgmt-test-creation"
 
   permissions = [
     "compute.instances.create",
@@ -168,7 +168,7 @@ resource "google_project_iam_custom_role" "disk_writer" {
   count       = var.enable_cloudscanners ? 1 : 0
   project     = local.project
   role_id     = "CloudScannerDiskWriter_${local.resource_suffix_underscore}"
-  title       = "Upwind Disk Writer"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-disk-writer"
   description = "Disk Write operations in orchestrator project"
 
   permissions = [
@@ -185,7 +185,7 @@ resource "google_project_iam_custom_role" "compute_service_agent_minimal" {
   count   = var.enable_cloudscanners ? 1 : 0
   project = local.project
   role_id = "ComputeServiceAgentMinimal_${local.resource_suffix_underscore}"
-  title   = "Minimal Compute Service Agent Permissions"
+  title   = "upwind-role-${local.resource_suffix_hyphen}-compute-service-agent-minimal"
 
   permissions = [
     "compute.disks.create",

--- a/modules/_shared/iam/service-accounts.tf
+++ b/modules/_shared/iam/service-accounts.tf
@@ -66,14 +66,6 @@ resource "google_service_account_iam_binding" "scaler_and_compute_can_use_clouds
   ]
 }
 
-# Allows the CloudScanner to impersonate the CloudScanner Scaler Service Account
-resource "google_service_account_iam_member" "cloudscanner_impersonate_scaler" {
-  count              = var.enable_cloudscanners ? 1 : 0
-  service_account_id = google_service_account.cloudscanner_scaler_sa[0].id
-  role               = "roles/iam.serviceAccountTokenCreator"
-  member             = "serviceAccount:${google_service_account.cloudscanner_sa[0].email}"
-}
-
 # Allow management SA to create tokens for scanner SA
 resource "google_service_account_iam_member" "management_can_impersonate_scanner" {
   count              = var.enable_cloudscanners ? 1 : 0

--- a/modules/folder/iam-roles-cloudscanner.tf
+++ b/modules/folder/iam-roles-cloudscanner.tf
@@ -9,7 +9,7 @@ resource "google_organization_iam_custom_role" "upwind_management_sa_iam_read_ro
 
   org_id      = var.gcp_organization_id
   role_id     = "CloudScannerFolderIamRead_${local.resource_suffix_underscore}"
-  title       = "upwind-mgmt-${local.resource_suffix_hyphen}-iam-read-folder"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-iam-read-folder"
   description = "Read permissions for IAM management across folders"
   permissions = module.iam.iam_read_role_permissions
 }
@@ -20,7 +20,7 @@ resource "google_organization_iam_custom_role" "snapshot_reader" {
 
   org_id      = var.gcp_organization_id
   role_id     = "CloudScannerFolderSnapshotReader_${local.resource_suffix_underscore}"
-  title       = "Upwind Snapshot Reader (Folder)"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-iam-read-folder"
   description = "Read-only access to all compute resources for discovery across folders"
 
   permissions = module.iam.snapshot_reader_permissions
@@ -32,7 +32,7 @@ resource "google_organization_iam_custom_role" "snapshot_creator" {
 
   org_id      = var.gcp_organization_id
   role_id     = "CloudScannerFolderSnapshotCreator_${local.resource_suffix_underscore}"
-  title       = "Upwind Snapshot Creator (Folder)"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-creator"
   description = "Snapshot Create operations across folder projects"
 
   permissions = module.iam.snapshot_creator_permissions
@@ -44,7 +44,7 @@ resource "google_organization_iam_custom_role" "snapshot_deleter" {
 
   org_id      = var.gcp_organization_id
   role_id     = "CloudScannerFolderSnapshotDeleter_${local.resource_suffix_underscore}"
-  title       = "Upwind Snapshot Deleter (Folder)"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-deleter"
   description = "Delete operations restricted to Upwind-managed resources across folders"
 
   permissions = module.iam.snapshot_deleter_permissions
@@ -56,7 +56,7 @@ resource "google_organization_iam_custom_role" "storage_object_reader" {
 
   org_id      = var.gcp_organization_id
   role_id     = "CloudScannerFolderStorageObjectReader_${local.resource_suffix_underscore}"
-  title       = "Upwind Storage Object Reader (Folder)"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-object-reader"
   description = "Read-only access to storage objects across folders"
 
   permissions = module.iam.storage_object_reader_permissions

--- a/modules/folder/iam-roles-cloudscanner.tf
+++ b/modules/folder/iam-roles-cloudscanner.tf
@@ -3,7 +3,7 @@
 # Generic operations role for CloudScanner
 resource "google_organization_iam_custom_role" "upwind_cloudscanner_operations_role" {
   count       = var.enable_cloudscanners ? 1 : 0
-  org_id      = data.google_organization.org.org_id
+  org_id      = var.gcp_organization_id
   role_id     = "CloudScannerOperationsRole_${local.resource_suffix_underscore}"
   title       = "upwind-role-${local.resource_suffix_hyphen}-cloudscanner-operations"
   description = "Generic Operations role for CloudScanner"
@@ -45,7 +45,7 @@ resource "google_folder_iam_binding" "upwind_cloudscanner_operations_role_bindin
   for_each = var.enable_cloudscanners ? toset(var.target_folder_ids) : toset([])
 
   folder = each.value
-  role   = google_organization_iam_custom_role.cloudscanner_operations_role[0].id
+  role   = google_organization_iam_custom_role.upwind_cloudscanner_operations_role[0].id
   members = [
     "serviceAccount:${module.iam.cloudscanner_sa.email}",
     "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
@@ -57,7 +57,7 @@ resource "google_folder_iam_binding" "upwind_cloudscanner_snapshot_deleter_role_
   for_each = var.enable_cloudscanners ? toset(var.target_folder_ids) : toset([])
 
   folder = each.value
-  role   = google_organization_iam_custom_role.cloudscanner_snapshot_deleter_role[0].id
+  role   = google_organization_iam_custom_role.upwind_cloudscanner_snapshot_deleter_role[0].id
   members = [
     "serviceAccount:${module.iam.cloudscanner_sa.email}",
     "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"

--- a/modules/folder/iam-roles-cloudscanner.tf
+++ b/modules/folder/iam-roles-cloudscanner.tf
@@ -1,88 +1,35 @@
 ### Folder-Level CloudScanner Roles
-# These provide permissions that inherit to all projects under the folder
 
-### Custom Roles created at folder level for inheritance
-
-# IAM read role for service account and role management (organization-wide)
-resource "google_organization_iam_custom_role" "upwind_management_sa_iam_read_role" {
-  count = var.enable_cloudscanners ? 1 : 0
-
-  org_id      = var.gcp_organization_id
-  role_id     = "CloudScannerFolderIamRead_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-iam-read-folder"
-  description = "Read permissions for IAM management across folders"
-  permissions = module.iam.iam_read_role_permissions
+# Generic operations role for CloudScanner
+resource "google_organization_iam_custom_role" "upwind_cloudscanner_operations_role" {
+  count       = var.enable_cloudscanners ? 1 : 0
+  org_id      = data.google_organization.org.org_id
+  role_id     = "CloudScannerOperationsRole_${local.resource_suffix_underscore}"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-cloudscanner-operations"
+  description = "Generic Operations role for CloudScanner"
+  permissions = concat(
+    module.iam.iam_read_role_permissions,
+    module.iam.snapshot_reader_permissions,
+    module.iam.snapshot_creator_permissions,
+    module.iam.cloud_run_permissions,
+    module.iam.storage_read_permissions,
+    var.enable_dspm_scanning ? module.iam.storage_object_reader_permissions : [],
+  )
 }
 
 # Snapshot reader role for compute resources discovery (organization-wide)
-resource "google_organization_iam_custom_role" "snapshot_reader" {
+resource "google_organization_iam_custom_role" "upwind_cloudscanner_snapshot_deleter_role" {
   count = var.enable_cloudscanners ? 1 : 0
 
   org_id      = var.gcp_organization_id
-  role_id     = "CloudScannerFolderSnapshotReader_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-iam-read-folder"
-  description = "Read-only access to all compute resources for discovery across folders"
-
-  permissions = module.iam.snapshot_reader_permissions
-}
-
-# Snapshot creator role (organization-wide)
-resource "google_organization_iam_custom_role" "snapshot_creator" {
-  count = var.enable_cloudscanners ? 1 : 0
-
-  org_id      = var.gcp_organization_id
-  role_id     = "CloudScannerFolderSnapshotCreator_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-creator"
-  description = "Snapshot Create operations across folder projects"
-
-  permissions = module.iam.snapshot_creator_permissions
-}
-
-# Snapshot deleter role (organization-wide)
-resource "google_organization_iam_custom_role" "snapshot_deleter" {
-  count = var.enable_cloudscanners ? 1 : 0
-
-  org_id      = var.gcp_organization_id
-  role_id     = "CloudScannerFolderSnapshotDeleter_${local.resource_suffix_underscore}"
+  role_id     = "CloudScannerSnapshotDeleter_${local.resource_suffix_underscore}"
   title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-deleter"
-  description = "Delete operations restricted to Upwind-managed resources across folders"
+  description = "Delete operations restricted to Upwind-managed resources"
 
   permissions = module.iam.snapshot_deleter_permissions
 }
 
-# Storage object reader role (organization-wide)
-resource "google_organization_iam_custom_role" "storage_object_reader" {
-  count = var.enable_cloudscanners && var.enable_dspm ? 1 : 0
-
-  org_id      = var.gcp_organization_id
-  role_id     = "CloudScannerFolderStorageObjectReader_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-object-reader"
-  description = "Read-only access to storage objects across folders"
-
-  permissions = module.iam.storage_object_reader_permissions
-}
-
-# Cloud Run scanning role (organization-wide)
-resource "google_organization_iam_custom_role" "cloudscanner_cloud_run_role" {
-  count = var.enable_cloudscanners ? 1 : 0
-
-  org_id      = var.gcp_organization_id
-  role_id     = "CloudScannerFolderCloudRun_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-cloud-run-folder"
-  description = "CloudScanner permissions for Cloud Run scanning across folders"
-  permissions = module.iam.cloud_run_permissions
-}
-
 ### Folder-Level IAM Bindings (inherited by all projects in folder)
-
-# Assign IAM read role to management service account on each target folder
-resource "google_folder_iam_member" "upwind_management_sa_iam_read_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_folder_ids) : toset([])
-
-  folder = each.value
-  role   = google_organization_iam_custom_role.upwind_management_sa_iam_read_role[0].id
-  member = "serviceAccount:${module.iam.upwind_management_sa.email}"
-}
 
 # Grant compute viewer role to CloudScanner SA on each target folder
 resource "google_folder_iam_member" "upwind_cloudscanner_sa_compute_viewer_role_member" {
@@ -94,80 +41,30 @@ resource "google_folder_iam_member" "upwind_cloudscanner_sa_compute_viewer_role_
 }
 
 # Grant snapshot reader role to CloudScanner and Scaler SAs on each target folder
-resource "google_folder_iam_member" "cloudscanner_snapshot_reader" {
+resource "google_folder_iam_binding" "upwind_cloudscanner_operations_role_binding" {
   for_each = var.enable_cloudscanners ? toset(var.target_folder_ids) : toset([])
 
   folder = each.value
-  role   = google_organization_iam_custom_role.snapshot_reader[0].id
-  member = "serviceAccount:${module.iam.cloudscanner_sa.email}"
-}
-
-resource "google_folder_iam_member" "scaler_snapshot_reader" {
-  for_each = var.enable_cloudscanners ? toset(var.target_folder_ids) : toset([])
-
-  folder = each.value
-  role   = google_organization_iam_custom_role.snapshot_reader[0].id
-  member = "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
-}
-
-# Grant snapshot creator role to CloudScanner and Scaler SAs on each target folder
-resource "google_folder_iam_member" "cloudscanner_snapshot_creator_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_folder_ids) : toset([])
-
-  folder = each.value
-  role   = google_organization_iam_custom_role.snapshot_creator[0].id
-  member = "serviceAccount:${module.iam.cloudscanner_sa.email}"
-}
-
-resource "google_folder_iam_member" "scaler_snapshot_creator_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_folder_ids) : toset([])
-
-  folder = each.value
-  role   = google_organization_iam_custom_role.snapshot_creator[0].id
-  member = "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
+  role   = google_organization_iam_custom_role.cloudscanner_operations_role[0].id
+  members = [
+    "serviceAccount:${module.iam.cloudscanner_sa.email}",
+    "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
+  ]
 }
 
 # Grant snapshot deleter role with conditions
-resource "google_folder_iam_member" "cloudscanner_snapshot_deleter_role_member" {
+resource "google_folder_iam_binding" "upwind_cloudscanner_snapshot_deleter_role_binding" {
   for_each = var.enable_cloudscanners ? toset(var.target_folder_ids) : toset([])
 
   folder = each.value
-  role   = google_organization_iam_custom_role.snapshot_deleter[0].id
-  member = "serviceAccount:${module.iam.cloudscanner_sa.email}"
+  role   = google_organization_iam_custom_role.cloudscanner_snapshot_deleter_role[0].id
+  members = [
+    "serviceAccount:${module.iam.cloudscanner_sa.email}",
+    "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
+  ]
 
   condition {
-    title      = "Upwind Cloud Scanner Snapshot Writer"
+    title      = "Upwind Cloud Scanner Snapshot Deleter"
     expression = "resource.name.extract('snapshots/{snapshot}').startsWith('snap-')"
   }
-}
-
-resource "google_folder_iam_member" "scaler_snapshot_deleter_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_folder_ids) : toset([])
-
-  folder = each.value
-  role   = google_organization_iam_custom_role.snapshot_deleter[0].id
-  member = "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
-
-  condition {
-    title      = "Upwind Cloud Scanner Snapshot Writer"
-    expression = "resource.name.extract('snapshots/{snapshot}').startsWith('snap-')"
-  }
-}
-
-# Grant storage object reader role to CloudScanner SA on each target folder
-resource "google_folder_iam_member" "cloudscanner_sa_storage_object_reader_role_member" {
-  for_each = var.enable_cloudscanners && var.enable_dspm ? toset(var.target_folder_ids) : toset([])
-
-  folder = each.value
-  role   = google_organization_iam_custom_role.storage_object_reader[0].id
-  member = "serviceAccount:${module.iam.cloudscanner_sa.email}"
-}
-
-# Grant Cloud Run role to CloudScanner SA on each target folder
-resource "google_folder_iam_member" "cloudscanner_cloud_run_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_folder_ids) : toset([])
-
-  folder = each.value
-  role   = google_organization_iam_custom_role.cloudscanner_cloud_run_role[0].id
-  member = "serviceAccount:${module.iam.cloudscanner_sa.email}"
 }

--- a/modules/folder/iam-roles.tf
+++ b/modules/folder/iam-roles.tf
@@ -6,7 +6,7 @@
 resource "google_organization_iam_custom_role" "storage_reader_role" {
   org_id      = var.gcp_organization_id
   role_id     = "UpwindFolderStorageReader_${local.resource_suffix_underscore}"
-  title       = "Upwind Management SA Storage Reader (Folder)"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-reader"
   description = "Custom role for Upwind Management Service Account to read storage buckets across folders."
 
   permissions = module.iam.storage_read_permissions

--- a/modules/folder/iam-roles.tf
+++ b/modules/folder/iam-roles.tf
@@ -2,7 +2,7 @@
 
 # Custom role for Storage reader and IAM management with minimal required permissions
 resource "google_organization_iam_custom_role" "upwind_management_sa_operations_role" {
-  org_id      = data.google_organization.org.org_id
+  org_id      = var.gcp_organization_id
   role_id     = "UpwindOperations_${local.resource_suffix_underscore}"
   title       = "upwind-role-${local.resource_suffix_hyphen}-operations"
   description = "Generic operations role for Upwind"

--- a/modules/folder/iam-roles.tf
+++ b/modules/folder/iam-roles.tf
@@ -1,15 +1,15 @@
 ### Folder-Level IAM for Multi-Project Access via Folder Inheritance
 
-### Custom Roles (created at folder level for inheritance)
-
-# Storage reader role (organization-wide, applied to folders)
-resource "google_organization_iam_custom_role" "storage_reader_role" {
-  org_id      = var.gcp_organization_id
-  role_id     = "UpwindFolderStorageReader_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-reader"
-  description = "Custom role for Upwind Management Service Account to read storage buckets across folders."
-
-  permissions = module.iam.storage_read_permissions
+# Custom role for Storage reader and IAM management with minimal required permissions
+resource "google_organization_iam_custom_role" "upwind_management_sa_operations_role" {
+  org_id      = data.google_organization.org.org_id
+  role_id     = "UpwindOperations_${local.resource_suffix_underscore}"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-operations"
+  description = "Generic operations role for Upwind"
+  permissions = concat(
+    module.iam.storage_read_permissions,
+    var.enable_cloudscanners ? module.iam.iam_read_role_permissions : [],
+  )
 }
 
 # Give the management service account the basic viewer role on each target folder
@@ -22,11 +22,11 @@ resource "google_folder_iam_member" "upwind_management_sa_folder_viewer_role_mem
 }
 
 # Grant custom storage reader role to management SA on each target folder
-resource "google_folder_iam_member" "upwind_management_sa_storage_reader_role_member" {
+resource "google_folder_iam_member" "upwind_management_sa_operations_role_member" {
   for_each = toset(var.target_folder_ids)
 
   folder = each.value
-  role   = google_organization_iam_custom_role.storage_reader_role.id
+  role   = google_organization_iam_custom_role.upwind_management_sa_operations_role.id
   member = "serviceAccount:${module.iam.upwind_management_sa.email}"
 }
 
@@ -37,13 +37,4 @@ resource "google_folder_iam_member" "upwind_management_sa_asset_viewer_role_memb
   folder = each.value
   role   = "roles/cloudasset.viewer"
   member = "serviceAccount:${module.iam.upwind_management_sa.email}"
-}
-
-# Required for DSPM functionality when cloudscanners are enabled
-resource "google_folder_iam_member" "cloudscanner_sa_storage_reader_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_folder_ids) : toset([])
-
-  folder = each.value
-  role   = google_organization_iam_custom_role.storage_reader_role.id
-  member = "serviceAccount:${module.iam.cloudscanner_sa.email}"
 }

--- a/modules/folder/outputs.tf
+++ b/modules/folder/outputs.tf
@@ -47,18 +47,3 @@ output "folder_projects_map" {
     ]
   }
 }
-
-output "organization_custom_roles" {
-  description = "Organization-level custom roles created for folder access"
-  value = {
-    storage_reader_role = google_organization_iam_custom_role.storage_reader_role.id
-    cloudscanner_roles = var.enable_cloudscanners ? {
-      iam_read_role              = google_organization_iam_custom_role.upwind_management_sa_iam_read_role[0].id
-      snapshot_reader_role       = google_organization_iam_custom_role.snapshot_reader[0].id
-      snapshot_creator_role      = google_organization_iam_custom_role.snapshot_creator[0].id
-      snapshot_deleter_role      = google_organization_iam_custom_role.snapshot_deleter[0].id
-      cloud_run_role             = google_organization_iam_custom_role.cloudscanner_cloud_run_role[0].id
-      storage_object_reader_role = var.enable_dspm ? google_organization_iam_custom_role.storage_object_reader[0].id : null
-    } : null
-  }
-}

--- a/modules/folder/variables.tf
+++ b/modules/folder/variables.tf
@@ -116,12 +116,6 @@ variable "enable_dspm_scanning" {
   default     = false
 }
 
-variable "enable_dspm" {
-  description = "Enable DSPM functionality"
-  type        = bool
-  default     = false
-}
-
 variable "google_service_account_display_name" {
   description = "The display name for the service account."
   type        = string

--- a/modules/folder/variables.tf
+++ b/modules/folder/variables.tf
@@ -110,6 +110,12 @@ variable "enable_cloudscanners" {
   default     = false
 }
 
+variable "enable_dspm_scanning" {
+  description = "Enable DSPM scanning by cloud scanners"
+  type        = bool
+  default     = false
+}
+
 variable "enable_dspm" {
   description = "Enable DSPM functionality"
   type        = bool

--- a/modules/multiproject/iam-roles-cloudscanner.tf
+++ b/modules/multiproject/iam-roles-cloudscanner.tf
@@ -9,7 +9,7 @@ resource "google_project_iam_custom_role" "upwind_management_sa_iam_read_role" {
 
   project     = each.value
   role_id     = "CloudScannerIamReadRole_${local.resource_suffix_underscore}"
-  title       = "upwind-mgmt-${local.resource_suffix_hyphen}-iam-read"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-iam-read"
   description = "Read permissions for IAM management"
   permissions = module.iam.iam_read_role_permissions
 }
@@ -20,7 +20,7 @@ resource "google_project_iam_custom_role" "snapshot_reader" {
 
   project     = each.value
   role_id     = "CloudScannerSnapshotReader_${local.resource_suffix_underscore}"
-  title       = "Upwind Snapshot Reader"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-reader"
   description = "Read-only access to all compute resources for discovery"
 
   permissions = module.iam.snapshot_reader_permissions
@@ -32,7 +32,7 @@ resource "google_project_iam_custom_role" "snapshot_creator" {
 
   project     = each.value
   role_id     = "CloudScannerSnapshotCreator_${local.resource_suffix_underscore}"
-  title       = "Upwind Snapshot Creator"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-creator"
   description = "Snapshot Create operations in project"
 
   permissions = module.iam.snapshot_creator_permissions
@@ -44,7 +44,7 @@ resource "google_project_iam_custom_role" "snapshot_deleter" {
 
   project     = each.value
   role_id     = "CloudScannerSnapshotDeleter_${local.resource_suffix_underscore}"
-  title       = "Upwind Snapshot Deleter"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-deleter"
   description = "Delete operations restricted to Upwind-managed resources"
 
   permissions = module.iam.snapshot_deleter_permissions
@@ -56,7 +56,7 @@ resource "google_project_iam_custom_role" "storage_object_reader" {
 
   project     = each.value
   role_id     = "CloudScannerStorageObjectReader_${local.resource_suffix_underscore}"
-  title       = "Upwind Storage Object Reader"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-object-reader"
   description = "Read-only access to storage objects"
 
   permissions = module.iam.storage_object_reader_permissions

--- a/modules/multiproject/iam-roles-cloudscanner.tf
+++ b/modules/multiproject/iam-roles-cloudscanner.tf
@@ -3,43 +3,25 @@
 
 ### Custom Roles created in each target project
 
-# IAM read role for service account and role management (per project)
-resource "google_project_iam_custom_role" "upwind_management_sa_iam_read_role" {
-  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
-
-  project     = each.value
-  role_id     = "CloudScannerIamReadRole_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-iam-read"
-  description = "Read permissions for IAM management"
-  permissions = module.iam.iam_read_role_permissions
-}
-
-# Snapshot reader role for compute resources discovery (per project)
-resource "google_project_iam_custom_role" "snapshot_reader" {
-  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
-
-  project     = each.value
-  role_id     = "CloudScannerSnapshotReader_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-reader"
-  description = "Read-only access to all compute resources for discovery"
-
-  permissions = module.iam.snapshot_reader_permissions
-}
-
-# Snapshot creator role (per project)
-resource "google_project_iam_custom_role" "snapshot_creator" {
-  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
-
-  project     = each.value
-  role_id     = "CloudScannerSnapshotCreator_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-creator"
-  description = "Snapshot Create operations in project"
-
-  permissions = module.iam.snapshot_creator_permissions
+# Generic operations role for CloudScanner
+resource "google_organization_iam_custom_role" "upwind_cloudscanner_operations_role" {
+  count       = var.enable_cloudscanners ? 1 : 0
+  org_id      = data.google_organization.org.org_id
+  role_id     = "CloudScannerOperationsRole_${local.resource_suffix_underscore}"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-cloudscanner-operations"
+  description = "Generic Operations role for CloudScanner"
+  permissions = concat(
+    module.iam.iam_read_role_permissions,
+    module.iam.snapshot_reader_permissions,
+    module.iam.snapshot_creator_permissions,
+    module.iam.cloud_run_permissions,
+    module.iam.storage_read_permissions,
+    var.enable_dspm_scanning ? module.iam.storage_object_reader_permissions : [],
+  )
 }
 
 # Snapshot deleter role (per project)
-resource "google_project_iam_custom_role" "snapshot_deleter" {
+resource "google_project_iam_custom_role" "upwind_cloudscanner_snapshot_deleter_role" {
   for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
 
   project     = each.value
@@ -50,40 +32,7 @@ resource "google_project_iam_custom_role" "snapshot_deleter" {
   permissions = module.iam.snapshot_deleter_permissions
 }
 
-# Storage object reader role (per project)
-resource "google_project_iam_custom_role" "storage_object_reader" {
-  for_each = var.enable_cloudscanners && var.enable_dspm ? toset(var.target_project_ids) : toset([])
-
-  project     = each.value
-  role_id     = "CloudScannerStorageObjectReader_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-object-reader"
-  description = "Read-only access to storage objects"
-
-  permissions = module.iam.storage_object_reader_permissions
-}
-
-# Cloud Run scanning role (per project)
-resource "google_project_iam_custom_role" "cloudscanner_cloud_run_role" {
-  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
-
-  project     = each.value
-  role_id     = "CloudScannerCloudRunRole_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-cloud-run"
-  description = "CloudScanner permissions for Cloud Run scanning"
-  permissions = module.iam.cloud_run_permissions
-}
-
-
 ### Project-Level IAM Bindings
-
-# Assign IAM read role to management service account on each target project
-resource "google_project_iam_member" "upwind_management_sa_iam_read_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
-
-  project = each.value
-  role    = google_project_iam_custom_role.upwind_management_sa_iam_read_role[each.key].id
-  member  = "serviceAccount:${module.iam.upwind_management_sa.email}"
-}
 
 # Grant compute viewer role to CloudScanner SA on each target project
 resource "google_project_iam_member" "upwind_cloudscanner_sa_compute_viewer_role_member" {
@@ -94,92 +43,31 @@ resource "google_project_iam_member" "upwind_cloudscanner_sa_compute_viewer_role
   member  = "serviceAccount:${module.iam.cloudscanner_sa.email}"
 }
 
-# Grant snapshot reader role to CloudScanner and Scaler SAs on each target project
 # Required to get disks and snapshots of target instances across projects
-# CloudScanner SA permissions
-resource "google_project_iam_member" "cloudscanner_snapshot_reader" {
+resource "google_project_iam_binding" "upwind_cloudscanner_operations_role_binding" {
   for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
 
   project = each.value
-  role    = google_project_iam_custom_role.snapshot_reader[each.key].id
-  member  = "serviceAccount:${module.iam.cloudscanner_sa.email}"
+  role    = google_project_iam_custom_role.cloudscanner_operations_role[each.key].id
+  members = [
+    "serviceAccount:${module.iam.cloudscanner_sa.email}",
+    "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
+  ]
 }
 
 # Scaler SA permissions
-resource "google_project_iam_member" "scaler_snapshot_reader" {
+resource "google_project_iam_binding" "upwind_cloudscanner_snapshot_deleter_role_binding" {
   for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
 
   project = each.value
-  role    = google_project_iam_custom_role.snapshot_reader[each.key].id
-  member  = "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
-}
-
-# Grant snapshot creator role to CloudScanner and Scaler SAs on each target project
-# Required for CloudScanner to create snapshots in any project
-# Snapshot creation happens in the same project as the source disk
-# so we need to allow snapshot creation in all projects
-# CloudScanner SA snapshot creator permissions
-resource "google_project_iam_member" "cloudscanner_snapshot_creator_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
-
-  project = each.value
-  role    = google_project_iam_custom_role.snapshot_creator[each.key].id
-  member  = "serviceAccount:${module.iam.cloudscanner_sa.email}"
-}
-
-# Scaler SA snapshot creator permissions
-resource "google_project_iam_member" "scaler_snapshot_creator_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
-
-  project = each.value
-  role    = google_project_iam_custom_role.snapshot_creator[each.key].id
-  member  = "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
-}
-
-# CloudScanner SA snapshot deleter permissions with condition
-resource "google_project_iam_member" "cloudscanner_snapshot_deleter_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
-
-  project = each.value
-  role    = google_project_iam_custom_role.snapshot_deleter[each.key].id
-  member  = "serviceAccount:${module.iam.cloudscanner_sa.email}"
-
+  role    = google_project_iam_custom_role.cloudscanner_snapshot_deleter_role[each.key].id
+  members = [
+    "serviceAccount:${module.iam.cloudscanner_sa.email}",
+    "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
+  ]
   condition {
     # Limit deletion permissions to snapshots we generate only
-    title      = "Upwind Cloud Scanner Snapshot Writer"
+    title      = "Upwind Cloud Scanner Snapshot Deleter"
     expression = "resource.name.extract('snapshots/{snapshot}').startsWith('snap-')"
   }
-}
-
-# Scaler SA snapshot deleter permissions with condition
-resource "google_project_iam_member" "scaler_snapshot_deleter_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
-
-  project = each.value
-  role    = google_project_iam_custom_role.snapshot_deleter[each.key].id
-  member  = "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
-
-  condition {
-    # Limit deletion permissions to snapshots we generate only
-    title      = "Upwind Cloud Scanner Snapshot Writer"
-    expression = "resource.name.extract('snapshots/{snapshot}').startsWith('snap-')"
-  }
-}
-
-# Grant storage object reader role to CloudScanner SA on each target project
-resource "google_project_iam_member" "cloudscanner_sa_storage_object_reader_role_member" {
-  for_each = var.enable_cloudscanners && var.enable_dspm ? toset(var.target_project_ids) : toset([])
-
-  project = each.value
-  role    = google_project_iam_custom_role.storage_object_reader[each.key].id
-  member  = "serviceAccount:${module.iam.cloudscanner_sa.email}"
-}
-
-# Grant Cloud Run role to CloudScanner SA on each target project
-resource "google_project_iam_member" "cloudscanner_cloud_run_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
-
-  project = each.value
-  role    = google_project_iam_custom_role.cloudscanner_cloud_run_role[each.key].id
-  member  = "serviceAccount:${module.iam.cloudscanner_sa.email}"
 }

--- a/modules/multiproject/iam-roles-cloudscanner.tf
+++ b/modules/multiproject/iam-roles-cloudscanner.tf
@@ -4,9 +4,10 @@
 ### Custom Roles created in each target project
 
 # Generic operations role for CloudScanner
-resource "google_organization_iam_custom_role" "upwind_cloudscanner_operations_role" {
-  count       = var.enable_cloudscanners ? 1 : 0
-  org_id      = data.google_organization.org.org_id
+resource "google_project_iam_custom_role" "upwind_cloudscanner_operations_role" {
+  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
+
+  project     = each.value
   role_id     = "CloudScannerOperationsRole_${local.resource_suffix_underscore}"
   title       = "upwind-role-${local.resource_suffix_hyphen}-cloudscanner-operations"
   description = "Generic Operations role for CloudScanner"
@@ -48,7 +49,7 @@ resource "google_project_iam_binding" "upwind_cloudscanner_operations_role_bindi
   for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
 
   project = each.value
-  role    = google_project_iam_custom_role.cloudscanner_operations_role[each.key].id
+  role    = google_project_iam_custom_role.upwind_cloudscanner_operations_role[each.key].id
   members = [
     "serviceAccount:${module.iam.cloudscanner_sa.email}",
     "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
@@ -60,7 +61,7 @@ resource "google_project_iam_binding" "upwind_cloudscanner_snapshot_deleter_role
   for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
 
   project = each.value
-  role    = google_project_iam_custom_role.cloudscanner_snapshot_deleter_role[each.key].id
+  role    = google_project_iam_custom_role.upwind_cloudscanner_snapshot_deleter_role[each.key].id
   members = [
     "serviceAccount:${module.iam.cloudscanner_sa.email}",
     "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"

--- a/modules/multiproject/iam-roles.tf
+++ b/modules/multiproject/iam-roles.tf
@@ -9,7 +9,7 @@ resource "google_project_iam_custom_role" "storage_reader_role" {
 
   project     = each.value
   role_id     = "UpwindStorageReader_${local.resource_suffix_underscore}"
-  title       = "Upwind Management SA Storage Reader"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-reader"
   description = "Custom role for Upwind Management Service Account to read storage buckets."
 
   permissions = module.iam.storage_read_permissions

--- a/modules/multiproject/iam-roles.tf
+++ b/modules/multiproject/iam-roles.tf
@@ -2,18 +2,21 @@
 
 ### Custom Roles (created in each target project)
 
-# Specifically grant permissions to read storage objects
-# This is a reduction from the storageAdmin role to grant read only access
-resource "google_project_iam_custom_role" "storage_reader_role" {
+# Custom role for Storage reader and IAM management with minimal required permissions
+resource "google_project_iam_custom_role" "upwind_management_sa_operations_role" {
   for_each = toset(var.target_project_ids)
 
   project     = each.value
-  role_id     = "UpwindStorageReader_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-reader"
-  description = "Custom role for Upwind Management Service Account to read storage buckets."
-
-  permissions = module.iam.storage_read_permissions
+  role_id     = "UpwindOperations_${local.resource_suffix_underscore}"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-operations"
+  description = "Generic operations role for Upwind"
+  permissions = concat(
+    module.iam.storage_read_permissions,
+    var.enable_cloudscanners ? module.iam.iam_read_role_permissions : [],
+  )
 }
+
+### IAM Members
 
 # Give the management service account the basic viewer role on each target project
 # We will grant more permissions if Cloud Scanners are enabled
@@ -25,12 +28,12 @@ resource "google_project_iam_member" "upwind_management_sa_project_viewer_role_m
   member  = "serviceAccount:${module.iam.upwind_management_sa.email}"
 }
 
-# Grant custom storage reader role to management SA on each target project
-resource "google_project_iam_member" "upwind_management_sa_storage_reader_role_member" {
+# Grant custom operations role to management SA on each target project
+resource "google_project_iam_member" "upwind_management_sa_operations_role_member" {
   for_each = toset(var.target_project_ids)
 
   project = each.value
-  role    = google_project_iam_custom_role.storage_reader_role[each.key].id
+  role    = google_project_iam_custom_role.upwind_management_sa_operations_role[each.key].id
   member  = "serviceAccount:${module.iam.upwind_management_sa.email}"
 }
 
@@ -41,13 +44,4 @@ resource "google_project_iam_member" "upwind_management_sa_asset_viewer_role_mem
   project = each.value
   role    = "roles/cloudasset.viewer"
   member  = "serviceAccount:${module.iam.upwind_management_sa.email}"
-}
-
-# Required for DSPM functionality when cloudscanners are enabled
-resource "google_project_iam_member" "cloudscanner_sa_storage_reader_role_member" {
-  for_each = var.enable_cloudscanners ? toset(var.target_project_ids) : toset([])
-
-  project = each.value
-  role    = google_project_iam_custom_role.storage_reader_role[each.key].id
-  member  = "serviceAccount:${module.iam.cloudscanner_sa.email}"
 }

--- a/modules/multiproject/variables.tf
+++ b/modules/multiproject/variables.tf
@@ -106,12 +106,6 @@ variable "enable_dspm_scanning" {
   default     = false
 }
 
-variable "enable_dspm" {
-  description = "Enable DSPM functionality"
-  type        = bool
-  default     = false
-}
-
 variable "google_service_account_display_name" {
   description = "The display name for the service account."
   type        = string

--- a/modules/multiproject/variables.tf
+++ b/modules/multiproject/variables.tf
@@ -100,6 +100,12 @@ variable "enable_cloudscanners" {
   default     = false
 }
 
+variable "enable_dspm_scanning" {
+  description = "Enable DSPM scanning by cloud scanners"
+  type        = bool
+  default     = false
+}
+
 variable "enable_dspm" {
   description = "Enable DSPM functionality"
   type        = bool

--- a/modules/organization/iam-roles-cloudscanner.tf
+++ b/modules/organization/iam-roles-cloudscanner.tf
@@ -4,7 +4,7 @@ resource "google_organization_iam_custom_role" "upwind_management_sa_iam_read_ro
   count       = var.enable_cloudscanners ? 1 : 0
   org_id      = data.google_organization.org.org_id
   role_id     = "CloudScannerIamReadRole_${local.resource_suffix_underscore}"
-  title       = "upwind-mgmt-${local.resource_suffix_hyphen}-iam-read"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-iam-read"
   description = "Read permissions for IAM management"
   permissions = module.iam.iam_read_role_permissions
 }
@@ -14,7 +14,7 @@ resource "google_organization_iam_custom_role" "snapshot_reader" {
   count       = var.enable_cloudscanners ? 1 : 0
   org_id      = data.google_organization.org.org_id
   role_id     = "CloudScannerSnapshotReader_${local.resource_suffix_underscore}"
-  title       = "Upwind Snapshot Reader"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-reader"
   description = "Read-only access to all compute resources for discovery"
 
   permissions = module.iam.snapshot_reader_permissions
@@ -24,7 +24,7 @@ resource "google_organization_iam_custom_role" "snapshot_creator" {
   count       = var.enable_cloudscanners ? 1 : 0
   org_id      = data.google_organization.org.org_id
   role_id     = "CloudScannerSnapshotCreator_${local.resource_suffix_underscore}"
-  title       = "Upwind Snapshot Creator"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-creator"
   description = "Snapshot Create operations in any project"
 
   permissions = module.iam.snapshot_creator_permissions
@@ -34,7 +34,7 @@ resource "google_organization_iam_custom_role" "snapshot_deleter" {
   count       = var.enable_cloudscanners ? 1 : 0
   org_id      = data.google_organization.org.org_id
   role_id     = "CloudScannerSnapshotDeleter_${local.resource_suffix_underscore}"
-  title       = "Upwind Snapshot Deleter"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-deleter"
   description = "Delete operations restricted to Upwind-managed resources"
 
   permissions = module.iam.snapshot_deleter_permissions
@@ -45,7 +45,7 @@ resource "google_organization_iam_custom_role" "storage_object_reader" {
   count       = var.enable_cloudscanners && var.enable_dspm_scanning ? 1 : 0
   org_id      = data.google_organization.org.org_id
   role_id     = "CloudScannerStorageObjectReader_${local.resource_suffix_underscore}"
-  title       = "Upwind Storage Object Reader"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-object-reader"
   description = "Read-only access to storage objects"
 
   permissions = module.iam.storage_object_reader_permissions

--- a/modules/organization/iam-roles-cloudscanner.tf
+++ b/modules/organization/iam-roles-cloudscanner.tf
@@ -38,7 +38,7 @@ resource "google_organization_iam_member" "upwind_cloudscanner_sa_compute_viewer
 resource "google_organization_iam_binding" "upwind_cloudscanner_operations_role_binding" {
   count  = var.enable_cloudscanners ? 1 : 0
   org_id = data.google_organization.org.org_id
-  role   = google_organization_iam_custom_role.cloudscanner_operations_role[0].name
+  role   = google_organization_iam_custom_role.upwind_cloudscanner_operations_role[0].name
   members = [
     "serviceAccount:${module.iam.cloudscanner_sa.email}",
     "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
@@ -49,7 +49,7 @@ resource "google_organization_iam_binding" "upwind_cloudscanner_operations_role_
 resource "google_organization_iam_binding" "upwind_cloudscanner_snapshot_deleter_role_binding" {
   count  = var.enable_cloudscanners ? 1 : 0
   org_id = data.google_organization.org.org_id
-  role   = google_organization_iam_custom_role.cloudscanner_snapshot_deleter_role[0].name
+  role   = google_organization_iam_custom_role.upwind_cloudscanner_snapshot_deleter_role[0].name
   members = [
     "serviceAccount:${module.iam.cloudscanner_sa.email}",
     "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"

--- a/modules/organization/iam-roles-cloudscanner.tf
+++ b/modules/organization/iam-roles-cloudscanner.tf
@@ -1,27 +1,22 @@
-# Custom role for IAM management with minimal required permissions
-# Read-only IAM role for service account and role management
-resource "google_organization_iam_custom_role" "upwind_management_sa_iam_read_role" {
+# Generic operations role for CloudScanner
+resource "google_organization_iam_custom_role" "upwind_cloudscanner_operations_role" {
   count       = var.enable_cloudscanners ? 1 : 0
   org_id      = data.google_organization.org.org_id
-  role_id     = "CloudScannerIamReadRole_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-iam-read"
-  description = "Read permissions for IAM management"
-  permissions = module.iam.iam_read_role_permissions
-}
-
-# Custom role for snapshot management
-resource "google_organization_iam_custom_role" "cloudscanner_snapshot_operations_role" {
-  count       = var.enable_cloudscanners ? 1 : 0
-  org_id      = data.google_organization.org.org_id
-  role_id     = "CloudScannerSnapshotOperations_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-snapshot-operations"
-  description = "Operations on snapshots for CloudScanner"
-
-  permissions = concat(module.iam.snapshot_reader_permissions, module.iam.snapshot_creator_permissions)
+  role_id     = "CloudScannerOperationsRole_${local.resource_suffix_underscore}"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-cloudscanner-operations"
+  description = "Generic Operations role for CloudScanner"
+  permissions = concat(
+    module.iam.iam_read_role_permissions,
+    module.iam.snapshot_reader_permissions,
+    module.iam.snapshot_creator_permissions,
+    module.iam.cloud_run_permissions,
+    module.iam.storage_read_permissions,
+    var.enable_dspm_scanning ? module.iam.storage_object_reader_permissions : [],
+  )
 }
 
 # Snapshot deleter role separate to limit delete permissions to named resources
-resource "google_organization_iam_custom_role" "cloudscanner_snapshot_deleter_role" {
+resource "google_organization_iam_custom_role" "upwind_cloudscanner_snapshot_deleter_role" {
   count       = var.enable_cloudscanners ? 1 : 0
   org_id      = data.google_organization.org.org_id
   role_id     = "CloudScannerSnapshotDeleter_${local.resource_suffix_underscore}"
@@ -29,35 +24,6 @@ resource "google_organization_iam_custom_role" "cloudscanner_snapshot_deleter_ro
   description = "Delete operations restricted to Upwind-managed resources"
 
   permissions = module.iam.snapshot_deleter_permissions
-}
-
-# Grants access to storage bucket objects for DSPM functionality
-resource "google_organization_iam_custom_role" "storage_object_reader" {
-  count       = var.enable_cloudscanners && var.enable_dspm_scanning ? 1 : 0
-  org_id      = data.google_organization.org.org_id
-  role_id     = "CloudScannerStorageObjectReader_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-object-reader"
-  description = "Read-only access to storage objects"
-
-  permissions = module.iam.storage_object_reader_permissions
-}
-
-# Required for Cloud Run scanning
-resource "google_organization_iam_custom_role" "cloudscanner_cloud_run_role" {
-  count       = var.enable_cloudscanners ? 1 : 0
-  org_id      = data.google_organization.org.org_id
-  role_id     = "CloudScannerCloudRunRole_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-cloud-run"
-  permissions = module.iam.cloud_run_permissions
-}
-
-
-# Assign the read IAM role to the management service account (unconditional)
-resource "google_organization_iam_member" "upwind_management_sa_iam_read_role_member" {
-  count  = var.enable_cloudscanners ? 1 : 0
-  org_id = data.google_organization.org.org_id
-  role   = google_organization_iam_custom_role.upwind_management_sa_iam_read_role[0].id
-  member = "serviceAccount:${module.iam.upwind_management_sa.email}"
 }
 
 # Required to get instances across projects
@@ -69,10 +35,10 @@ resource "google_organization_iam_member" "upwind_cloudscanner_sa_compute_viewer
 }
 
 # Required to get disks and snapshots of target instances across projects
-resource "google_organization_iam_binding" "upwind_cloudscanner_snapshot_reader_role_binding" {
+resource "google_organization_iam_binding" "upwind_cloudscanner_operations_role_binding" {
   count  = var.enable_cloudscanners ? 1 : 0
   org_id = data.google_organization.org.org_id
-  role   = google_organization_iam_custom_role.cloudscanner_snapshot_operations_role[0].name
+  role   = google_organization_iam_custom_role.cloudscanner_operations_role[0].name
   members = [
     "serviceAccount:${module.iam.cloudscanner_sa.email}",
     "serviceAccount:${module.iam.cloudscanner_scaler_sa.email}"
@@ -80,7 +46,7 @@ resource "google_organization_iam_binding" "upwind_cloudscanner_snapshot_reader_
 }
 
 # Limit snapshot deletion permissions to Upwind-generated snapshots only
-resource "google_organization_iam_binding" "cloudscanner_scaler_snapshot_deleter_role_binding" {
+resource "google_organization_iam_binding" "upwind_cloudscanner_snapshot_deleter_role_binding" {
   count  = var.enable_cloudscanners ? 1 : 0
   org_id = data.google_organization.org.org_id
   role   = google_organization_iam_custom_role.cloudscanner_snapshot_deleter_role[0].name
@@ -90,23 +56,7 @@ resource "google_organization_iam_binding" "cloudscanner_scaler_snapshot_deleter
   ]
   condition {
     # Limit storage deletion permissions to snapshots we generate only
-    title      = "Upwind Cloud Scanner Snapshot Writer"
+    title      = "Upwind Cloud Scanner Snapshot Deleter"
     expression = "resource.name.extract('snapshots/{snapshot}').startsWith('snap-')"
   }
-}
-
-resource "google_organization_iam_binding" "cloudscanner_sa_storage_object_reader_role_binding" {
-  count  = var.enable_cloudscanners && var.enable_dspm_scanning ? 1 : 0
-  org_id = data.google_organization.org.org_id
-  role   = google_organization_iam_custom_role.storage_object_reader[0].name
-  members = [
-    "serviceAccount:${module.iam.cloudscanner_sa.email}",
-  ]
-}
-
-resource "google_organization_iam_member" "cloudscanner_cloud_run_role_member" {
-  count  = var.enable_cloudscanners ? 1 : 0
-  org_id = data.google_organization.org.org_id
-  role   = google_organization_iam_custom_role.cloudscanner_cloud_run_role[0].name
-  member = "serviceAccount:${module.iam.cloudscanner_sa.email}"
 }

--- a/modules/organization/iam-roles.tf
+++ b/modules/organization/iam-roles.tf
@@ -1,3 +1,17 @@
+### Custom Roles
+
+# Custom role for Storage reader and IAM management with minimal required permissions
+resource "google_organization_iam_custom_role" "upwind_management_sa_operations_role" {
+  org_id      = data.google_organization.org.org_id
+  role_id     = "UpwindOperations_${local.resource_suffix_underscore}"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-operations"
+  description = "Generic operations role for Upwind"
+  permissions = concat(
+    module.iam.storage_read_permissions,
+    var.enable_cloudscanners ? module.iam.iam_read_role_permissions : [],
+  )
+}
+
 ### IAM Members
 
 # Give the management service account the basic viewer role
@@ -14,20 +28,10 @@ resource "google_organization_iam_member" "upwind_management_sa_folder_viewer_ro
   member = "serviceAccount:${module.iam.upwind_management_sa.email}"
 }
 
-# Specifically grant permissions to read storage objects
-# This is a reduction from the storageAdmin role to grant read only access
-resource "google_organization_iam_custom_role" "storage_reader_role" {
-  org_id      = data.google_organization.org.org_id
-  role_id     = "UpwindStorageReader_${local.resource_suffix_underscore}"
-  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-reader"
-  description = "Custom role for Upwind Management Service Account to read storage buckets."
-
-  permissions = module.iam.storage_read_permissions
-}
-
-resource "google_organization_iam_member" "upwind_management_sa_storage_reader_role_member" {
+# Assign the operations role to the management service account (unconditional)
+resource "google_organization_iam_member" "upwind_management_sa_operations_role_member" {
   org_id = data.google_organization.org.org_id
-  role   = google_organization_iam_custom_role.storage_reader_role.id
+  role   = google_organization_iam_custom_role.upwind_management_sa_operations_role.id
   member = "serviceAccount:${module.iam.upwind_management_sa.email}"
 }
 
@@ -36,12 +40,4 @@ resource "google_organization_iam_member" "upwind_management_sa_asset_viewer_rol
   org_id = data.google_organization.org.org_id
   role   = "roles/cloudasset.viewer"
   member = "serviceAccount:${module.iam.upwind_management_sa.email}"
-}
-
-# Required for DSPM functionality when cloudscanners are enabled
-resource "google_organization_iam_member" "cloudscanner_sa_storage_reader_role_member" {
-  count  = var.enable_cloudscanners ? 1 : 0
-  org_id = data.google_organization.org.org_id
-  role   = google_organization_iam_custom_role.storage_reader_role.id
-  member = "serviceAccount:${module.iam.cloudscanner_sa.email}"
 }

--- a/modules/organization/iam-roles.tf
+++ b/modules/organization/iam-roles.tf
@@ -19,7 +19,7 @@ resource "google_organization_iam_member" "upwind_management_sa_folder_viewer_ro
 resource "google_organization_iam_custom_role" "storage_reader_role" {
   org_id      = data.google_organization.org.org_id
   role_id     = "UpwindStorageReader_${local.resource_suffix_underscore}"
-  title       = "Upwind Management SA Storage Reader"
+  title       = "upwind-role-${local.resource_suffix_hyphen}-storage-reader"
   description = "Custom role for Upwind Management Service Account to read storage buckets."
 
   permissions = module.iam.storage_read_permissions

--- a/modules/organization/variables.tf
+++ b/modules/organization/variables.tf
@@ -104,7 +104,7 @@ variable "enable_cloudscanners" {
 variable "enable_dspm_scanning" {
   description = "Enable DSPM scanning by cloud scanners"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "google_service_account_display_name" {


### PR DESCRIPTION
- Reducing number of deployed roles as far as possible, since quotas are generally low
- Consistent titles and names
- Removing `getAccessToken` permission, which is not needed and is a broad permission

Controlling included permissions by variables rather than separating roles, but some still need to be separated where conditions are required.