### PR TITLE
fix(AG-4070): add missing permissions for certain cases

### DIFF
--- a/modules/_shared/iam/permissions.tf
+++ b/modules/_shared/iam/permissions.tf
@@ -6,6 +6,7 @@ variable "deployment_permissions" {
     "compute.instanceTemplates.create",
     "compute.instanceTemplates.delete",
     "compute.instanceTemplates.get",
+    "compute.instanceTemplates.useReadOnly",
     "compute.instanceGroupManagers.create",
     "compute.instanceGroupManagers.delete",
     "compute.instanceGroupManagers.get",
@@ -41,6 +42,9 @@ variable "deployment_permissions" {
     "run.jobs.create",
     "run.jobs.get",
     "run.jobs.delete",
+    "run.operations.get",
+    "run.operations.list",
+    "run.executions.get",
     "run.executions.list",
     # Cloud Scheduler creation permissions
     "cloudscheduler.jobs.create",
@@ -108,6 +112,7 @@ variable "cloudscanner_secret_access_permissions" {
   default = [
     # Permissions for accessing secrets in Secret Manager
     "secretmanager.versions.access",
+    "secretmanager.versions.get",
     "secretmanager.versions.list",
     "secretmanager.secrets.get",
     "secretmanager.secrets.list",


### PR DESCRIPTION
Permissions found to be missing during Confluent scanner deployment. These permissions do not show up as missing in dev, suspect it's related to specific SCP configurations.

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # module.upwind_integration_gcp_onboarding.module.iam.google_project_iam_custom_role.cloudscanner_secret_access_role[0] will be updated in-place
  ~ resource "google_project_iam_custom_role" "cloudscanner_secret_access_role" {
        id          = "projects/upwindsecurity-xa-w2/roles/CloudScannerSecretAccessRole_cc7a2_wkrjgegs"
        name        = "projects/upwindsecurity-xa-w2/roles/CloudScannerSecretAccessRole_cc7a2_wkrjgegs"
      ~ permissions = [
          + "secretmanager.versions.get",
            # (4 unchanged elements hidden)
        ]
        # (6 unchanged attributes hidden)
    }

  # module.upwind_integration_gcp_onboarding.module.iam.google_project_iam_custom_role.upwind_management_sa_cloudscanner_deployment_role[0] will be updated in-place
  ~ resource "google_project_iam_custom_role" "upwind_management_sa_cloudscanner_deployment_role" {
        id          = "projects/upwindsecurity-xa-w2/roles/CloudScannerDeploymentRole_cc7a2_wkrjgegs"
        name        = "projects/upwindsecurity-xa-w2/roles/CloudScannerDeploymentRole_cc7a2_wkrjgegs"
      ~ permissions = [
          + "compute.instanceTemplates.useReadOnly",
          + "run.executions.get",
          + "run.operations.get",
          + "run.operations.list",
            # (49 unchanged elements hidden)
        ]
        # (6 unchanged attributes hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```