### PR TITLE
fix(AG-4659): scaler lambda requires compute.instances.delete when it falls back to directly removing vm insances in the clean up job

### DIFF
--- a/modules/_shared/iam/permissions.tf
+++ b/modules/_shared/iam/permissions.tf
@@ -104,6 +104,7 @@ variable "cloudscanner_scaler_permissions" {
     "compute.globalOperations.get",         # The internal implementation queries the global operations when removing snapshots.
     "compute.subnetworks.get",
     "compute.subnetworks.use",
+    "compute.instances.delete",
   ]
 }
 


### PR DESCRIPTION
The scaling lambda fails to remove VM instances via the direct removal method if the MIG removal fails due to permission error
`error: "googleapi: Error 403: Required 'compute.instances.delete' permission for 'projects/upwindsecurity-xa-w2/zones/us-east1-d/instances/upwind-vm-dspm-ucsc-67a86096472388e9-3kpz'"`

This adds `compute.instances.delete` to the `cloudscanner_scaler_role` to allow this operation