### PR TITLE
chore: upgrade actions/checkout and semantic-release-action to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3
@@ -68,7 +68,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Cache TFLint Plugin Directory
       uses: actions/cache@v3
@@ -98,7 +98,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run Trivy Security Scanner
       uses: aquasecurity/trivy-action@v0.35.0
@@ -127,7 +127,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run Terraform Docs
       uses: terraform-docs/gh-actions@v1.4.1
@@ -166,7 +166,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/discover.yml
+++ b/.github/workflows/discover.yml
@@ -19,7 +19,7 @@ jobs:
       examples: ${{ steps.set-matrix.outputs.examples }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set Matrix
       id: set-matrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       is_manual: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -77,7 +77,7 @@ jobs:
     - name: Semantic Release
       id: semantic-release
       if: github.event_name == 'push'
-      uses: cycjimmy/semantic-release-action@v4
+      uses: cycjimmy/semantic-release-action@v6
       with:
         semantic_version: 24.2.5
         # Only install plugins that are not built-in to semantic-release


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` to v6 (latest: v6.0.2)
- Upgrade `cycjimmy/semantic-release-action` to v6 (latest: v6.0.0)

## Why
Keep GitHub Actions dependencies up to date for security patches and new features.

## Changes
Automated find-and-replace across all workflow files in this repo.
